### PR TITLE
Adiciona pagination a lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
-## [Unreleased]
+## 0.0.2
+- Adiciona paginação em elementos que retornam array e possum pagination no objeto de resposta
 
+## 0.0.1
 - Início da Gem Conexa Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conexa (0.0.1)
+    conexa (0.0.2)
       jwt
       multi_json
       rest-client

--- a/lib/conexa/request.rb
+++ b/lib/conexa/request.rb
@@ -27,7 +27,7 @@ module Conexa
       response = RestClient::Request.execute request_params
 
       response = MultiJson.decode response.body
-      response.dig("data") || response
+      return {data: response.dig("data") || response, pagination: response.dig("pagination")}
 
 
       rescue RestClient::Exception => error
@@ -61,7 +61,10 @@ module Conexa
     end
 
     def call(ressource_name)
-      ConexaObject.convert run, ressource_name
+      dt = run
+      return ConexaObject.convert({data: ConexaObject.convert(dt[:data], ressource_name), pagination: ConexaObject.convert(dt[:pagination], "pagination")}, "result") if dt[:pagination]
+
+      ConexaObject.convert(dt[:data], ressource_name)
     end
 
     def self.get(url, options={})

--- a/lib/conexa/request.rb
+++ b/lib/conexa/request.rb
@@ -62,7 +62,12 @@ module Conexa
 
     def call(ressource_name)
       dt = run
-      return ConexaObject.convert({data: ConexaObject.convert(dt[:data], ressource_name), pagination: ConexaObject.convert(dt[:pagination], "pagination")}, "result") if dt[:pagination]
+
+      if dt[:pagination]
+        return ConexaObject.convert({
+          data: ConexaObject.convert(dt[:data], ressource_name),
+          pagination: ConexaObject.convert(dt[:pagination], "pagination")}, "result")
+      end
 
       ConexaObject.convert(dt[:data], ressource_name)
     end

--- a/lib/conexa/resources/addres.rb
+++ b/lib/conexa/resources/addres.rb
@@ -1,0 +1,4 @@
+module Conexa
+  class Addres  < ConexaObject
+  end
+end

--- a/lib/conexa/resources/address.rb
+++ b/lib/conexa/resources/address.rb
@@ -1,4 +1,0 @@
-module Conexa
-  class Address  < ConexaObject
-  end
-end

--- a/lib/conexa/resources/pagination.rb
+++ b/lib/conexa/resources/pagination.rb
@@ -1,0 +1,4 @@
+module Conexa
+  class Pagination  < ConexaObject
+  end
+end

--- a/lib/conexa/resources/result.rb
+++ b/lib/conexa/resources/result.rb
@@ -1,0 +1,19 @@
+module Conexa
+  class Result  < ConexaObject
+
+    def inspect
+      self.data.inspect
+    end
+
+    def method_missing(name, *args, &block)
+      name = Util.to_snake_case(name.to_s)
+
+      if @attributes["data"].respond_to?(name) && args != ["data"]
+        return @attributes["data"].public_send name, *args, &block
+      end
+
+      super name, *args, &block
+    end
+
+  end
+end

--- a/lib/conexa/resources/result.rb
+++ b/lib/conexa/resources/result.rb
@@ -5,11 +5,32 @@ module Conexa
       self.data.inspect
     end
 
+    def respond_to?(name, include_all = false)
+      return true if name.to_s.end_with? '='
+
+      @attributes.has_key?(name.to_s) ||      super
+    end
+
     def method_missing(name, *args, &block)
       name = Util.to_snake_case(name.to_s)
 
-      if @attributes["data"].respond_to?(name) && args != ["data"]
-        return @attributes["data"].public_send name, *args, &block
+      unless block_given?
+        if @attributes["data"] && @attributes["data"].respond_to?(name) && args != ["data"]
+          return @attributes["data"].public_send name, *args, &block
+        end
+
+        if name.end_with?('=') && args.size == 1
+          attribute_name = name[0...-1]
+          return self[attribute_name] = args[0]
+        end
+
+        if args.size == 0
+          return self[name] || self[name.to_sym]
+        end
+      end
+
+      if attributes.respond_to? name
+        return attributes.public_send name, *args, &block
       end
 
       super name, *args, &block

--- a/lib/conexa/version.rb
+++ b/lib/conexa/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Conexa
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Adiciona objeto de paginação nas respostas que retornam array. 

Para acessar basta:
```ruby 
ret = Conexa::Customer.all

ret.pagination
=> #<Conexa::Pagination:0x0000741d0f19d0e8
 @attributes={"item_per_page"=>5, "current_page"=>1, "total_pages"=>29, "total_items"=>145},
 @unsaved_attributes=#<Set: {}>>

ret.first
# Returns first item of data array

```

todos os métodos não encontrados são passados para a instância que salva os dados. Assim este responde a todos os métodos disponíveis no array, ou objeto de saída da requisição. 