### PR TITLE
fix: add nil guard to camelize_hash to prevent NoMethodError

### DIFF
--- a/lib/conexa/util.rb
+++ b/lib/conexa/util.rb
@@ -51,6 +51,8 @@ module Conexa
 
 
       def camelize_hash(hash)
+        return {} if hash.nil?
+
         new_hash = {}
 
         hash.each do |key, value|

--- a/spec/conexa/util_spec.rb
+++ b/spec/conexa/util_spec.rb
@@ -80,6 +80,30 @@ RSpec.describe Conexa::Util do
 
       expect(result).to eq(expected_output)
     end
+
+    it 'retorna hash vazio quando recebe nil' do
+      result = described_class.camelize_hash(nil)
+
+      expect(result).to eq({})
+    end
+
+    it 'trata valores nil dentro do hash sem erros' do
+      input_hash = { first_name: 'John', middle_name: nil, last_name: 'Doe' }
+      expected_output = { firstName: 'John', middleName: nil, lastName: 'Doe' }
+
+      result = described_class.camelize_hash(input_hash)
+
+      expect(result).to eq(expected_output)
+    end
+
+    it 'trata hash aninhado com valores nil' do
+      input_hash = { user_info: { first_name: 'John', address: nil } }
+      expected_output = { userInfo: { firstName: 'John', address: nil } }
+
+      result = described_class.camelize_hash(input_hash)
+
+      expect(result).to eq(expected_output)
+    end
   end
 
   describe '.camel_case_lower' do


### PR DESCRIPTION
## 🐛 Bug

Quando `camelize_hash` recebe `nil` em vez de um hash (ex: resposta inesperada da API), lança:

```
NoMethodError: undefined method `each` for nil:NilClass
```

## ✅ Fix

Adiciona guard clause para retornar hash vazio quando nil é passado:

```ruby
def camelize_hash(hash)
  return {} if hash.nil?  # ✅ Guard adicionado
  # ...
end
```

## 🧪 Testes

- `camelize_hash(nil)` → retorna `{}`
- Hash com valores nil → preserva nil
- Hash aninhado com nil → funciona

## 📋 Contexto

Erro encontrado no Checkbits ao fazer fetch de cliente do Conexa:

```
[ADDRESS_IMPORT] Conexa fetch error: undefined method `each` for nil:NilClass
    hash.each do |key, value|
```