### PR TITLE
fix: delegate empty? to data in Result class

### DIFF
--- a/lib/conexa/resources/result.rb
+++ b/lib/conexa/resources/result.rb
@@ -5,6 +5,13 @@ module Conexa
       self.data.inspect
     end
 
+    # Delegate empty? to data array instead of checking @attributes
+    # This fixes the case where Conexa returns empty results but
+    # @attributes still has pagination info, making empty? return false
+    def empty?
+      data.nil? || data.empty?
+    end
+
     def pagination
       @attributes["pagination"]
     end

--- a/spec/conexa/resources/result_spec.rb
+++ b/spec/conexa/resources/result_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Conexa::Result do
+  describe '#empty?' do
+    context 'when data is an empty array' do
+      let(:result) do
+        described_class.new(
+          'data' => [],
+          'pagination' => {
+            'item_per_page' => 100,
+            'current_page' => 1,
+            'total_pages' => 0,
+            'total_items' => 0
+          }
+        )
+      end
+
+      it 'returns true' do
+        expect(result.empty?).to be true
+      end
+
+      it 'still has pagination info' do
+        expect(result.pagination).to be_a(Conexa::Pagination)
+        expect(result.pagination.total_items).to eq(0)
+      end
+    end
+
+    context 'when data has items' do
+      let(:result) do
+        described_class.new(
+          'data' => [{ 'id' => 1, 'name' => 'Customer 1' }],
+          'pagination' => {
+            'item_per_page' => 100,
+            'current_page' => 1,
+            'total_pages' => 1,
+            'total_items' => 1
+          }
+        )
+      end
+
+      it 'returns false' do
+        expect(result.empty?).to be false
+      end
+    end
+
+    context 'when data is nil' do
+      let(:result) do
+        described_class.new(
+          'pagination' => {
+            'item_per_page' => 100,
+            'current_page' => 1,
+            'total_pages' => 0,
+            'total_items' => 0
+          }
+        )
+      end
+
+      it 'returns true' do
+        expect(result.empty?).to be true
+      end
+    end
+  end
+
+  describe '#pagination' do
+    let(:result) do
+      described_class.new(
+        'data' => [],
+        'pagination' => {
+          'item_per_page' => 50,
+          'current_page' => 2,
+          'total_pages' => 5,
+          'total_items' => 250
+        }
+      )
+    end
+
+    it 'returns pagination object' do
+      expect(result.pagination).to be_a(Conexa::Pagination)
+    end
+
+    it 'has correct pagination values' do
+      expect(result.pagination.item_per_page).to eq(50)
+      expect(result.pagination.current_page).to eq(2)
+      expect(result.pagination.total_pages).to eq(5)
+      expect(result.pagination.total_items).to eq(250)
+    end
+  end
+end


### PR DESCRIPTION
## 🐛 Bug (Issue #5)

Quando a API do Conexa retorna resultados vazios, `empty?` retorna `false` incorretamente:

```ruby
resp = Conexa::Customer.all(cnpj: "27.280.488/0001-04")
resp       # => []
resp.empty? # => false  ❌
```

**Causa:** `empty?` verifica `@attributes.empty?` que inclui `pagination`, então nunca é vazio.

## ✅ Fix

Sobrescreve `empty?` no `Result` para delegar para `data.empty?`:

```ruby
def empty?
  data.nil? || data.empty?
end
```

## 🧪 Testes

Adicionado `spec/conexa/resources/result_spec.rb` com testes para:
- `empty?` com data vazio → `true`
- `empty?` com data preenchido → `false`
- `empty?` com data nil → `true`
- Pagination acessível mesmo com data vazio

**Closes #5**