### PR TITLE
chore: release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.0.6
+### Bug Fixes
+- **camelize_hash nil guard** - Adiciona proteção contra `nil` no método `camelize_hash` para evitar `NoMethodError: undefined method 'each' for nil:NilClass` quando a API retorna resposta inesperada ([#6](https://github.com/guilhermegazzinelli/conexa-ruby/pull/6))
+- **Result#empty? delegation** - Corrige `empty?` no `Result` para delegar para `data.empty?` ao invés de verificar `@attributes.empty?`. Isso corrige o caso onde resultados vazios retornavam `false` em `empty?` devido à presença de dados de paginação ([#7](https://github.com/guilhermegazzinelli/conexa-ruby/pull/7), closes [#5](https://github.com/guilhermegazzinelli/conexa-ruby/issues/5))
+
+### Tests
+- Adiciona testes para `camelize_hash` com input `nil`
+- Adiciona spec completo para `Conexa::Result` (`spec/conexa/resources/result_spec.rb`)
+
 ## 0.0.5
 - Adiciona novos recursos: `InvoicingMethod`, `CreditCard`, `Supplier`, `Company`
 - Adiciona sub-processos em recursos existentes:
@@ -12,7 +21,6 @@
 ## 0.0.4
 - Adiciona paginação em elementos que retornam array e possuam pagination no objeto de resposta
 - Adiciona delegação para métodos com blocos ao receber um Conexa::Result
-
 
 ## 0.0.1
 - Início da Gem Conexa Ruby

--- a/conexa.gemspec
+++ b/conexa.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  # spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = "https://github.com/guilhermegazzinelli/conexa-ruby"
+  spec.metadata["changelog_uri"] = "https://github.com/guilhermegazzinelli/conexa-ruby/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/lib/conexa/version.rb
+++ b/lib/conexa/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Conexa
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
## Release 0.0.6

### Bug Fixes
- **camelize_hash nil guard** - Proteção contra nil no camelize_hash (#6)
- **Result#empty? delegation** - Corrige empty? para delegar para data (#7, closes #5)

### Changes
- Bump version 0.0.5 → 0.0.6
- Atualiza CHANGELOG.md
- Adiciona metadata URIs no gemspec

### Checklist
- [x] Version bump
- [x] CHANGELOG atualizado
- [x] Testes passando
- [ ] Merge → main
- [ ] Criar tag v0.0.6
- [ ] GitHub Release
- [ ] Publicar no RubyGems