### PR TITLE
fix: snake_case for Resource attributes + README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ end
 # List customers
 customers = Conexa::Customer.list
 customers.data.each do |customer|
-  puts "#{customer.customerId}: #{customer.name}"
+  puts "#{customer.customer_id}: #{customer.name}"
 end
 
 # Get a specific customer
@@ -57,6 +57,14 @@ puts customer.name
 puts customer.address.city
 ```
 
+## Convention
+
+This gem follows Ruby conventions:
+
+- **Parameters**: Use `snake_case` when calling methods - the gem automatically converts to `camelCase` for the API
+- **Responses**: API responses are converted from `camelCase` to `snake_case`
+- **Backwards compatibility**: `camelCase` methods are aliased (e.g., `customer.customer_id` and `customer.customerId` both work)
+
 ## Resources
 
 ### Customer
@@ -64,17 +72,17 @@ puts customer.address.city
 ```ruby
 # Create a customer (Legal Person - PJ)
 customer = Conexa::Customer.create(
-  companyId: 3,
+  company_id: 3,
   name: 'Empresa ABC Ltda',
-  tradeName: 'ABC',
-  cellNumber: '11999998888',
-  hasLoginAccess: false,
-  legalPerson: {
+  trade_name: 'ABC',
+  cell_number: '11999998888',
+  has_login_access: false,
+  legal_person: {
     cnpj: '99.557.155/0001-90',
-    foundationDate: '2020-06-12'
+    foundation_date: '2020-06-12'
   },
   address: {
-    zipCode: '13058-111',
+    zip_code: '13058-111',
     state: 'SP',
     city: 'Campinas',
     street: 'Rua Principal',
@@ -82,21 +90,21 @@ customer = Conexa::Customer.create(
     neighborhood: 'Centro'
   },
   phones: ['(11) 3333-4444'],
-  emailsMessage: ['contato@empresa.com'],
-  emailsFinancialMessages: ['financeiro@empresa.com']
+  emails_message: ['contato@empresa.com'],
+  emails_financial_messages: ['financeiro@empresa.com']
 )
 puts customer.id  # => 114
 
 # Create a customer (Natural Person - PF)
 customer = Conexa::Customer.create(
-  companyId: 3,
+  company_id: 3,
   name: 'João Silva',
-  naturalPerson: {
+  natural_person: {
     cpf: '516.079.209-05',
-    birthDate: '1990-05-15',
+    birth_date: '1990-05-15',
     profession: 'Developer'
   },
-  hasLoginAccess: true,
+  has_login_access: true,
   login: 'joao.silva',
   password: 'SecurePass123!'
 )
@@ -104,18 +112,18 @@ customer = Conexa::Customer.create(
 # Retrieve customer
 customer = Conexa::Customer.retrieve(127)
 customer.name           # => "Empresa ABC Ltda"
-customer.companyId      # => 3
-customer.isActive       # => true
+customer.company_id     # => 3
+customer.is_active      # => true
 customer.address.city   # => "Campinas"
-customer.legalPerson.cnpj  # => "99.557.155/0001-90"
+customer.legal_person['cnpj']  # => "99.557.155/0001-90"
 
 # Update customer
-Conexa::Customer.update(127, name: 'New Name', cellNumber: '11888887777')
+Conexa::Customer.update(127, name: 'New Name', cell_number: '11888887777')
 
 # List customers with filters
 customers = Conexa::Customer.list(
-  companyId: [3],
-  isActive: true,
+  company_id: [3],
+  is_active: true,
   page: 1,
   size: 20
 )
@@ -126,21 +134,21 @@ customers = Conexa::Customer.list(
 ```ruby
 # Create a contract
 contract = Conexa::Contract.create(
-  customerId: 127,
-  planId: 5,
-  startDate: '2024-01-01',
-  paymentDay: 10,
-  invoicingMethodId: 1
+  customer_id: 127,
+  plan_id: 5,
+  start_date: '2024-01-01',
+  payment_day: 10,
+  invoicing_method_id: 1
 )
 
 # Create contract with custom items
 contract = Conexa::Contract.create_with_products(
-  customerId: 127,
-  startDate: '2024-01-01',
-  paymentDay: 10,
+  customer_id: 127,
+  start_date: '2024-01-01',
+  payment_day: 10,
   items: [
-    { productId: 101, quantity: 1, amount: 299.90 },
-    { productId: 102, quantity: 2, amount: 49.90 }
+    { product_id: 101, quantity: 1, amount: 299.90 },
+    { product_id: 102, quantity: 2, amount: 49.90 }
   ]
 )
 
@@ -148,7 +156,7 @@ contract = Conexa::Contract.create_with_products(
 contract = Conexa::Contract.retrieve(456)
 
 # Cancel contract
-Conexa::Contract.cancel(456, cancelDate: '2024-12-31')
+Conexa::Contract.cancel(456, cancel_date: '2024-12-31')
 ```
 
 ### Sale (One-time)
@@ -156,12 +164,12 @@ Conexa::Contract.cancel(456, cancelDate: '2024-12-31')
 ```ruby
 # Create a one-time sale
 sale = Conexa::Sale.create(
-  customerId: 450,
-  requesterId: 458,
-  productId: 2521,
+  customer_id: 450,
+  requester_id: 458,
+  product_id: 2521,
   quantity: 1,
   amount: 80.99,
-  referenceDate: '2024-09-24T17:24:00-03:00',
+  reference_date: '2024-09-24T17:24:00-03:00',
   notes: 'WhatsApp order'
 )
 puts sale.id  # => 188481
@@ -170,14 +178,14 @@ puts sale.id  # => 188481
 sale = Conexa::Sale.retrieve(188510)
 sale.status         # => "notBilled"
 sale.amount         # => 80.99
-sale.discountValue  # => 69.21
+sale.discount_value # => 69.21
 
 # List sales
 sales = Conexa::Sale.list(
-  customerId: [450, 216],
+  customer_id: [450, 216],
   status: 'notBilled',
-  dateFrom: '2024-01-01',
-  dateTo: '2024-12-31',
+  date_from: '2024-01-01',
+  date_to: '2024-12-31',
   page: 1,
   size: 20
 )
@@ -194,14 +202,14 @@ Conexa::Sale.delete(188510)
 ```ruby
 # Create recurring sale
 recurring = Conexa::RecurringSale.create(
-  customerId: 127,
-  productId: 101,
+  customer_id: 127,
+  product_id: 101,
   quantity: 1,
-  startDate: '2024-01-01'
+  start_date: '2024-01-01'
 )
 
 # List recurring sales for a contract
-Conexa::RecurringSale.list(contractId: 456)
+Conexa::RecurringSale.list(contract_id: 456)
 ```
 
 ### Charge
@@ -209,16 +217,16 @@ Conexa::RecurringSale.list(contractId: 456)
 ```ruby
 # Retrieve charge
 charge = Conexa::Charge.retrieve(789)
-charge.status      # => "paid"
-charge.amount      # => 299.90
-charge.dueDate     # => "2024-02-10"
+charge.status     # => "paid"
+charge.amount     # => 299.90
+charge.due_date   # => "2024-02-10"
 
 # List charges
 charges = Conexa::Charge.list(
-  customerId: [127],
+  customer_id: [127],
   status: 'pending',
-  dueDateFrom: '2024-01-01',
-  dueDateTo: '2024-12-31'
+  due_date_from: '2024-01-01',
+  due_date_to: '2024-12-31'
 )
 
 # Cancel charge
@@ -236,7 +244,7 @@ bill = Conexa::Bill.retrieve(101)
 
 # List bills
 bills = Conexa::Bill.list(
-  customerId: [127],
+  customer_id: [127],
   page: 1,
   size: 50
 )
@@ -246,7 +254,7 @@ bills = Conexa::Bill.list(
 
 ```ruby
 # List plans
-plans = Conexa::Plan.list(companyId: [3])
+plans = Conexa::Plan.list(company_id: [3])
 
 # Retrieve plan
 plan = Conexa::Plan.retrieve(5)
@@ -258,7 +266,7 @@ plan.price  # => 99.90
 
 ```ruby
 # List products
-products = Conexa::Product.list(companyId: [3])
+products = Conexa::Product.list(company_id: [3])
 
 # Retrieve product
 product = Conexa::Product.retrieve(101)
@@ -269,19 +277,19 @@ product = Conexa::Product.retrieve(101)
 ```ruby
 # Add credit card to customer
 card = Conexa::CreditCard.create(
-  customerId: 127,
-  cardNumber: '4111111111111111',
-  cardholderName: 'JOAO SILVA',
-  expirationMonth: '12',
-  expirationYear: '2025',
+  customer_id: 127,
+  card_number: '4111111111111111',
+  cardholder_name: 'JOAO SILVA',
+  expiration_month: '12',
+  expiration_year: '2025',
   cvv: '123'
 )
 
 # List customer's cards
-cards = Conexa::CreditCard.list(customerId: 127)
+cards = Conexa::CreditCard.list(customer_id: 127)
 
 # Delete card
-Conexa::CreditCard.delete(cardId)
+Conexa::CreditCard.delete(card_id)
 ```
 
 ### Company (Unit)
@@ -303,17 +311,17 @@ All list endpoints return paginated results:
 ```ruby
 result = Conexa::Customer.list(page: 1, size: 20)
 
-result.data           # Array of customers
-result.pagination.currentPage   # => 1
-result.pagination.totalPages    # => 10
-result.pagination.totalItems    # => 195
-result.pagination.itemPerPage   # => 20
+result.data                       # Array of customers
+result.pagination.current_page    # => 1
+result.pagination.total_pages     # => 10
+result.pagination.total_items     # => 195
+result.pagination.item_per_page   # => 20
 
 # Iterate through pages
 loop do
   result.data.each { |customer| process(customer) }
-  break if result.pagination.currentPage >= result.pagination.totalPages
-  result = Conexa::Customer.list(page: result.pagination.currentPage + 1)
+  break if result.pagination.current_page >= result.pagination.total_pages
+  result = Conexa::Customer.list(page: result.pagination.current_page + 1)
 end
 ```
 
@@ -364,6 +372,7 @@ The Conexa API has a limit of **100 requests per minute**. Response headers incl
 - [API Documentation](https://conexa.app/api-docs)
 - [Postman Collection](https://documenter.getpostman.com/view/25182821/2s93RZMpcB)
 - [Discord Community](https://discord.gg/zW28sJh7Nz) - Conexa for Developers
+- [REFERENCE.md](REFERENCE.md) - Complete API reference for LLMs/AI agents
 
 ## Development
 

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -148,8 +148,8 @@ Conexa::Customer.all(name: "João", page: 1, size: 10)
 Conexa::Customer.all("id[]": [102, 103])
 
 # Filtrar por empresa
-Conexa::Customer.all("companyId[]": [3])
-Conexa::Contract.all("companyId[]": [540], page: 2, size: 5)
+Conexa::Customer.all("company_id[]": [3])
+Conexa::Contract.all("company_id[]": [540], page: 2, size: 5)
 
 # Múltiplos filtros combinados
 Conexa::Company.all(
@@ -174,13 +174,13 @@ Conexa::Sale.all(page: 2, size: 6)
 
 | Recurso | Filtros Comuns |
 |---------|---------------|
-| Customer | `name`, `id[]`, `companyId[]` |
+| Customer | `name`, `id[]`, `company_id[]` |
 | Company | `id[]`, `tradeName`, `legalName`, `cnpj`, `city`, `active` |
-| Contract | `companyId[]`, `active` |
-| Bill | `status`, `companyId[]` |
+| Contract | `company_id[]`, `active` |
+| Bill | `status`, `company_id[]` |
 | Plan | `id[]` |
 | Sale | `date` |
-| InvoicingMethod | `id[]`, `companyId[]`, `isActive`, `type` |
+| InvoicingMethod | `id[]`, `company_id[]`, `isActive`, `type` |
 
 ### Operações Específicas de Recursos (Sub-processos)
 
@@ -227,7 +227,7 @@ Conexa::RecurringSale.end_recurring_sale(recurring_sale_id, end_date: "2024-12-3
 
 ```ruby
 # Listar meios de faturamento com filtros
-Conexa::InvoicingMethod.all("companyId[]": [3], is_active: 1, type: "billet")
+Conexa::InvoicingMethod.all("company_id[]": [3], is_active: 1, type: "billet")
 
 # Buscar por ID
 Conexa::InvoicingMethod.find(invoicing_method_id)

--- a/lib/conexa/resources/auth.rb
+++ b/lib/conexa/resources/auth.rb
@@ -5,8 +5,8 @@ module Conexa
   # 
   # @example Authenticate with credentials
   #   auth = Conexa::Auth.login(username: 'admin', password: 'secret')
-  #   auth.accessToken  # => "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."
-  #   auth.expiresIn    # => 28800
+  #   auth.access_token  # => "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."
+  #   auth.expires_in    # => 28800
   #
   # @note For most cases, use Application Token instead (configured in Conexa.configure)
   class Auth < ConexaObject
@@ -15,13 +15,13 @@ module Conexa
       # 
       # @param username [String] Login username (admin or employee email)
       # @param password [String] Password
-      # @return [Auth] Authentication result with accessToken
+      # @return [Auth] Authentication result with access_token
       # @raise [Conexa::AuthenticationError] if credentials are invalid
       #
       # @example
       #   auth = Conexa::Auth.login(username: 'admin', password: 'mypassword')
       #   # Use the token for subsequent requests
-      #   Conexa.configure { |c| c.api_token = auth.accessToken }
+      #   Conexa.configure { |c| c.api_token = auth.access_token }
       def login(username:, password:)
         response = Conexa::Request.post('/auth', params: {
           username: username,
@@ -40,18 +40,21 @@ module Conexa
     end
 
     # @return [String] Token type (always "Bearer")
-    def tokenType
-      @attributes['tokenType']
+    def token_type
+      @attributes['token_type']
     end
+    alias_method :tokenType, :token_type
 
     # @return [String] JWT access token
-    def accessToken
-      @attributes['accessToken']
+    def access_token
+      @attributes['access_token']
     end
+    alias_method :accessToken, :access_token
 
     # @return [Integer] Token expiration time in seconds
-    def expiresIn
-      @attributes['expiresIn']
+    def expires_in
+      @attributes['expires_in']
     end
+    alias_method :expiresIn, :expires_in
   end
 end

--- a/lib/conexa/resources/charge.rb
+++ b/lib/conexa/resources/charge.rb
@@ -8,18 +8,18 @@ module Conexa
   #   charge.status  # => "pending"
   #
   # @example List charges
-  #   charges = Conexa::Charge.all(customerId: [127], status: 'pending')
+  #   charges = Conexa::Charge.all(customer_id: [127], status: 'pending')
   #
   # @example Settle (pay) a charge
   #   Conexa::Charge.settle(789)
   #
   class Charge < Model
     # @return [Integer] Charge ID
-    def chargeId
-      @attributes['chargeId']
+    def charge_id
+      @attributes['charge_id']
     end
-
-    alias_method :id, :chargeId
+    alias_method :chargeId, :charge_id
+    alias_method :id, :charge_id
 
     # @return [String] Charge status
     def status
@@ -32,14 +32,16 @@ module Conexa
     end
 
     # @return [String] Due date
-    def dueDate
-      @attributes['dueDate']
+    def due_date
+      @attributes['due_date']
     end
+    alias_method :dueDate, :due_date
 
     # @return [Integer] Customer ID
-    def customerId
-      @attributes['customerId']
+    def customer_id
+      @attributes['customer_id']
     end
+    alias_method :customerId, :customer_id
 
     # Check if charge is paid
     # @return [Boolean]

--- a/lib/conexa/resources/contract.rb
+++ b/lib/conexa/resources/contract.rb
@@ -5,22 +5,22 @@ module Conexa
   #
   # @example Create a contract
   #   contract = Conexa::Contract.create(
-  #     customerId: 127,
-  #     planId: 5,
-  #     startDate: '2024-01-01',
-  #     paymentDay: 10
+  #     customer_id: 127,
+  #     plan_id: 5,
+  #     start_date: '2024-01-01',
+  #     payment_day: 10
   #   )
   #
   # @example End a contract
-  #   Conexa::Contract.end_contract(456, endDate: '2024-12-31')
+  #   Conexa::Contract.end_contract(456, end_date: '2024-12-31')
   #
   class Contract < Model
     # @return [Integer] Contract ID
-    def contractId
-      @attributes['contractId']
+    def contract_id
+      @attributes['contract_id']
     end
-
-    alias_method :id, :contractId
+    alias_method :contractId, :contract_id
+    alias_method :id, :contract_id
 
     # @return [String] Contract status
     def status
@@ -28,29 +28,34 @@ module Conexa
     end
 
     # @return [Integer] Customer ID
-    def customerId
-      @attributes['customerId']
+    def customer_id
+      @attributes['customer_id']
     end
+    alias_method :customerId, :customer_id
 
     # @return [Integer, nil] Plan ID
-    def planId
-      @attributes['planId']
+    def plan_id
+      @attributes['plan_id']
     end
+    alias_method :planId, :plan_id
 
     # @return [String] Start date
-    def startDate
-      @attributes['startDate']
+    def start_date
+      @attributes['start_date']
     end
+    alias_method :startDate, :start_date
 
     # @return [String, nil] End date
-    def endDate
-      @attributes['endDate']
+    def end_date
+      @attributes['end_date']
     end
+    alias_method :endDate, :end_date
 
     # @return [Integer] Payment day (1-28)
-    def paymentDay
-      @attributes['paymentDay']
+    def payment_day
+      @attributes['payment_day']
     end
+    alias_method :paymentDay, :payment_day
 
     # Check if contract is active
     # @return [Boolean]
@@ -65,7 +70,7 @@ module Conexa
     end
 
     # End/terminate this contract
-    # @param params [Hash] options including :endDate, :reason
+    # @param params [Hash] options including :end_date, :reason
     # @return [self]
     def end_contract(params = {})
       Conexa::Request.post(self.class.show_url("end", primary_key), params: params).call(class_name)
@@ -75,7 +80,7 @@ module Conexa
     class << self
       # End a contract by ID
       # @param id [Integer, String] contract ID
-      # @param params [Hash] options including :endDate, :reason
+      # @param params [Hash] options including :end_date, :reason
       # @return [Contract]
       def end_contract(id, params = {})
         find(id).end_contract(params)

--- a/lib/conexa/resources/customer.rb
+++ b/lib/conexa/resources/customer.rb
@@ -5,9 +5,9 @@ module Conexa
   #
   # @example Create a customer (Legal Person - PJ)
   #   customer = Conexa::Customer.create(
-  #     companyId: 3,
+  #     company_id: 3,
   #     name: 'Empresa ABC Ltda',
-  #     legalPerson: { cnpj: '99.557.155/0001-90' }
+  #     legal_person: { cnpj: '99.557.155/0001-90' }
   #   )
   #
   # @example Retrieve a customer
@@ -15,20 +15,21 @@ module Conexa
   #   customer.name  # => "Empresa ABC Ltda"
   #
   # @example List customers
-  #   customers = Conexa::Customer.all(companyId: [3], isActive: true)
+  #   customers = Conexa::Customer.all(company_id: [3], is_active: true)
   #
   class Customer < Model
     # @return [Integer] Customer ID
-    def customerId
-      @attributes['customerId']
+    def customer_id
+      @attributes['customer_id']
     end
-
-    alias_method :id, :customerId
+    alias_method :customerId, :customer_id
+    alias_method :id, :customer_id
 
     # @return [Integer] Company/Unit ID
-    def companyId
-      @attributes['companyId']
+    def company_id
+      @attributes['company_id']
     end
+    alias_method :companyId, :company_id
 
     # @return [String] Customer name
     def name
@@ -36,34 +37,40 @@ module Conexa
     end
 
     # @return [String, nil] Trade name
-    def tradeName
-      @attributes['tradeName']
+    def trade_name
+      @attributes['trade_name']
     end
+    alias_method :tradeName, :trade_name
 
     # @return [Boolean] Whether customer has login access
-    def hasLoginAccess
-      @attributes['hasLoginAccess']
+    def has_login_access
+      @attributes['has_login_access']
     end
+    alias_method :hasLoginAccess, :has_login_access
 
     # @return [Boolean] Whether customer is active
-    def isActive
-      @attributes['isActive']
+    def is_active
+      @attributes['is_active']
     end
+    alias_method :isActive, :is_active
 
     # @return [Boolean] Whether customer is blocked
-    def isBlocked
-      @attributes['isBlocked']
+    def is_blocked
+      @attributes['is_blocked']
     end
+    alias_method :isBlocked, :is_blocked
 
     # @return [Boolean] Whether customer is a legal person (PJ)
-    def isJuridicalPerson
-      @attributes['isJuridicalPerson']
+    def is_juridical_person
+      @attributes['is_juridical_person']
     end
+    alias_method :isJuridicalPerson, :is_juridical_person
 
     # @return [Boolean] Whether customer is a foreigner
-    def isForeign
-      @attributes['isForeign']
+    def is_foreign
+      @attributes['is_foreign']
     end
+    alias_method :isForeign, :is_foreign
 
     # @return [Address, nil] Customer address
     def address
@@ -72,14 +79,16 @@ module Conexa
     end
 
     # @return [Hash, nil] Legal person data (CNPJ, etc.)
-    def legalPerson
-      @attributes['legalPerson']
+    def legal_person
+      @attributes['legal_person']
     end
+    alias_method :legalPerson, :legal_person
 
     # @return [Hash, nil] Natural person data (CPF, etc.)
-    def naturalPerson
-      @attributes['naturalPerson']
+    def natural_person
+      @attributes['natural_person']
     end
+    alias_method :naturalPerson, :natural_person
 
     # @return [Array<String>] Phone numbers
     def phones
@@ -87,45 +96,49 @@ module Conexa
     end
 
     # @return [Array<String>] Message emails
-    def emailsMessage
-      @attributes['emailsMessage'] || []
+    def emails_message
+      @attributes['emails_message'] || []
     end
+    alias_method :emailsMessage, :emails_message
 
     # @return [Array<String>] Financial emails
-    def emailsFinancialMessages
-      @attributes['emailsFinancialMessages'] || []
+    def emails_financial_messages
+      @attributes['emails_financial_messages'] || []
     end
+    alias_method :emailsFinancialMessages, :emails_financial_messages
 
     # @return [Array<Integer>] Tag IDs
-    def tagsId
-      @attributes['tagsId'] || []
+    def tags_id
+      @attributes['tags_id'] || []
     end
+    alias_method :tagsId, :tags_id
 
     # @return [String, nil] Created at timestamp (W3C format)
-    def createdAt
-      @attributes['createdAt']
+    def created_at
+      @attributes['created_at']
     end
+    alias_method :createdAt, :created_at
 
     class << self
       # List persons (requesters) for a customer
       # @param customer_id [Integer] Customer ID
       # @return [Result] List of persons
       def persons(customer_id)
-        Conexa::Person.all(customerId: customer_id)
+        Conexa::Person.all(customer_id: customer_id)
       end
 
       # List contracts for a customer
       # @param customer_id [Integer] Customer ID
       # @return [Result] List of contracts
       def contracts(customer_id)
-        Conexa::Contract.all(customerId: [customer_id])
+        Conexa::Contract.all(customer_id: [customer_id])
       end
 
       # List charges for a customer
       # @param customer_id [Integer] Customer ID
       # @return [Result] List of charges
       def charges(customer_id)
-        Conexa::Charge.all(customerId: [customer_id])
+        Conexa::Charge.all(customer_id: [customer_id])
       end
     end
   end

--- a/lib/conexa/resources/sale.rb
+++ b/lib/conexa/resources/sale.rb
@@ -5,22 +5,22 @@ module Conexa
   #
   # @example Create a sale
   #   sale = Conexa::Sale.create(
-  #     customerId: 450,
-  #     productId: 2521,
+  #     customer_id: 450,
+  #     product_id: 2521,
   #     quantity: 1,
   #     amount: 80.99
   #   )
   #
   # @example List sales
-  #   sales = Conexa::Sale.all(customerId: [450], status: 'notBilled')
+  #   sales = Conexa::Sale.all(customer_id: [450], status: 'notBilled')
   #
   class Sale < Model
     # @return [Integer] Sale ID
-    def saleId
-      @attributes['saleId']
+    def sale_id
+      @attributes['sale_id']
     end
-
-    alias_method :id, :saleId
+    alias_method :saleId, :sale_id
+    alias_method :id, :sale_id
 
     # @return [String] Sale status: paid, billed, cancelled, notBilled, 
     #   deductedFromQuota, billedCancelled, billedNegociated, partiallyPaid
@@ -29,24 +29,28 @@ module Conexa
     end
 
     # @return [Integer] Customer ID
-    def customerId
-      @attributes['customerId']
+    def customer_id
+      @attributes['customer_id']
     end
+    alias_method :customerId, :customer_id
 
     # @return [Integer, nil] Requester ID
-    def requesterId
-      @attributes['requesterId']
+    def requester_id
+      @attributes['requester_id']
     end
+    alias_method :requesterId, :requester_id
 
     # @return [Integer] Product ID
-    def productId
-      @attributes['productId']
+    def product_id
+      @attributes['product_id']
     end
+    alias_method :productId, :product_id
 
     # @return [Integer, nil] Seller (user) ID
-    def sellerId
-      @attributes['sellerId']
+    def seller_id
+      @attributes['seller_id']
     end
+    alias_method :sellerId, :seller_id
 
     # @return [Integer] Quantity
     def quantity
@@ -59,19 +63,22 @@ module Conexa
     end
 
     # @return [Float] Original amount before discount
-    def originalAmount
-      @attributes['originalAmount']
+    def original_amount
+      @attributes['original_amount']
     end
+    alias_method :originalAmount, :original_amount
 
     # @return [Float] Discount value
-    def discountValue
-      @attributes['discountValue']
+    def discount_value
+      @attributes['discount_value']
     end
+    alias_method :discountValue, :discount_value
 
     # @return [String] Reference date (W3C format)
-    def referenceDate
-      @attributes['referenceDate']
+    def reference_date
+      @attributes['reference_date']
     end
+    alias_method :referenceDate, :reference_date
 
     # @return [String, nil] Notes
     def notes
@@ -79,14 +86,16 @@ module Conexa
     end
 
     # @return [String, nil] Created at timestamp
-    def createdAt
-      @attributes['createdAt']
+    def created_at
+      @attributes['created_at']
     end
+    alias_method :createdAt, :created_at
 
     # @return [String] Updated at timestamp
-    def updatedAt
-      @attributes['updatedAt']
+    def updated_at
+      @attributes['updated_at']
     end
+    alias_method :updatedAt, :updated_at
 
     # Check if sale is billed
     # @return [Boolean]

--- a/spec/integration/charge_spec.rb
+++ b/spec/integration/charge_spec.rb
@@ -90,9 +90,7 @@ RSpec.describe "Charge Integration" do
     end
   end
 
-  # Skip: Bug - Resource methods use camelCase for @attributes but ConexaObject converts to snake_case
-  # See issue #13
-  describe "PIX operations", skip: "Bug: camelCase vs snake_case mismatch in attributes" do
+  describe "PIX operations" do
     before do
       stub_request(:get, /test\.conexa\.app.*charge\/123/)
         .to_return(status: 200, body: charge_response, headers: { "Content-Type" => "application/json" })
@@ -115,8 +113,7 @@ RSpec.describe "Charge Integration" do
     end
   end
 
-  # Skip: Bug - Resource methods use camelCase for @attributes but ConexaObject converts to snake_case
-  describe "settling a charge", skip: "Bug: camelCase vs snake_case mismatch in attributes" do
+  describe "settling a charge" do
     let(:settled_response) do
       {
         "chargeId" => 123,

--- a/spec/integration/contract_spec.rb
+++ b/spec/integration/contract_spec.rb
@@ -109,8 +109,7 @@ RSpec.describe "Contract Integration" do
     end
   end
 
-  # Skip: Bug - Resource methods use camelCase for @attributes but ConexaObject converts to snake_case
-  describe "ending a contract", skip: "Bug: camelCase vs snake_case mismatch in attributes" do
+  describe "ending a contract" do
     before do
       stub_request(:get, /test\.conexa\.app.*contract\/789/)
         .to_return(status: 200, body: contract_response, headers: { "Content-Type" => "application/json" })


### PR DESCRIPTION
## Changes

### Fix #14 - snake_case for @attributes access

All Resource methods now use snake_case to access `@attributes`, matching how `ConexaObject` stores them after conversion.

**Before (broken):**
```ruby
def chargeId
  @attributes["chargeId"]  # Returns nil!
end
```

**After (works):**
```ruby
def charge_id
  @attributes["charge_id"]  # Works!
end
alias_method :chargeId, :charge_id  # Backwards compat
```

### Resources updated:
- Auth (access_token, token_type, expires_in)
- Charge (charge_id, customer_id, due_date)
- Contract (contract_id, customer_id, plan_id, start_date, end_date, payment_day)
- Customer (customer_id, company_id, trade_name, is_active, etc.)
- Sale (sale_id, customer_id, product_id, etc.)

### README updates
- All examples now use snake_case
- Added "Convention" section explaining automatic conversion
- Backwards compatibility noted
- Link to REFERENCE.md for LLMs

Closes #14