### PR TITLE
refactor: DRY attribute definitions with DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Comprehensive README with usage examples for all resources
-- Auth resource for username/password authentication
-- Spec fixtures extracted from official Postman collection
-- YARD documentation for main resources (Customer, Sale, Charge, Contract)
-- Helper methods: `billed?`, `paid?`, `editable?`, `active?`, `ended?`
-- Customer convenience methods: `persons`, `contracts`, `charges`
-- Charge methods: `cancel`, `send_email`, `pix`
+## [0.0.7] - 2026-02-12
 
-### Fixed
-- Renamed `Addres` to `Address` (typo fix)
+### Added
+- REFERENCE.md - Complete API reference optimized for LLMs/AI agents
+- Comprehensive test suite (330+ specs)
+- `Model.primary_key_attribute` DSL for cleaner resource definitions
+- YARD documentation for all resource attributes (`@!attribute` directives)
+- Documentation for `method_missing` behavior in ConexaObject
 
 ### Changed
-- Improved documentation across all resources
+- **Convention**: Use `snake_case` for all Ruby code (gem auto-converts to camelCase for API)
+- README updated with snake_case examples and "Convention" section
+- Resource methods now use snake_case with camelCase aliases for backwards compatibility
+  - `customer.customer_id` (primary) / `customer.customerId` (alias)
+- Simplified resources using `method_missing` for attribute access (-280 lines)
 
-## [0.0.6] - 2024-02-11
+### Fixed
+- Resource attribute methods now correctly access snake_case keys in `@attributes`
+- Compound-named models (RecurringSale, CreditCard, InvoicingMethod) now have correct primary keys
+- Array attributes (`phones`, `emails_message`, etc.) return `[]` instead of `nil` when empty
+
+## [0.0.6] - 2026-02-11
 
 ### Fixed
 - `Result#empty?` now correctly delegates to data array
 - `Util.camelize_hash` guards against nil values
 
-## [0.0.5] - 2024-01-15
+## [0.0.5] - 2026-01-15
 
 ### Added
 - Initial release with core resources
@@ -37,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Charge with settle and PIX methods
 - Pagination support
 
-[Unreleased]: https://github.com/guilhermegazzinelli/conexa-ruby/compare/v0.0.6...HEAD
+[Unreleased]: https://github.com/guilhermegazzinelli/conexa-ruby/compare/v0.0.7...HEAD
+[0.0.7]: https://github.com/guilhermegazzinelli/conexa-ruby/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/guilhermegazzinelli/conexa-ruby/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/guilhermegazzinelli/conexa-ruby/releases/tag/v0.0.5

--- a/lib/conexa/model.rb
+++ b/lib/conexa/model.rb
@@ -1,5 +1,30 @@
 module Conexa
   class Model < ConexaObject
+    class << self
+      # DSL for defining attributes with snake_case + camelCase alias
+      # @example
+      #   attribute :customer_id
+      #   # Generates: customer_id method + customerId alias
+      def attribute(snake_name)
+        camel_name = Util.camelize(snake_name.to_s)
+
+        define_method(snake_name) do
+          @attributes[snake_name.to_s]
+        end
+
+        alias_method camel_name.to_sym, snake_name
+      end
+
+      # DSL for primary key attribute (also aliases to :id)
+      # @example
+      #   primary_key_attribute :charge_id
+      #   # Generates: charge_id method + chargeId alias + id alias
+      def primary_key_attribute(snake_name)
+        attribute(snake_name)
+        alias_method :id, snake_name
+      end
+    end
+
     def create
       set_primary_key Conexa::Request.post(self.class.show_url, params: to_hash).call(class_name).attributes['id']
       fetch

--- a/lib/conexa/model.rb
+++ b/lib/conexa/model.rb
@@ -1,11 +1,12 @@
 module Conexa
   class Model < ConexaObject
     class << self
-      # DSL for defining attributes with snake_case + camelCase alias
+      # DSL for primary key attribute with :id alias
+      # Other attributes work via method_missing
       # @example
-      #   attribute :customer_id
-      #   # Generates: customer_id method + customerId alias
-      def attribute(snake_name)
+      #   primary_key_attribute :charge_id
+      #   # Generates: charge_id method + chargeId alias + id alias
+      def primary_key_attribute(snake_name)
         camel_name = Util.camelize_str(snake_name.to_s)
 
         define_method(snake_name) do
@@ -13,14 +14,6 @@ module Conexa
         end
 
         alias_method camel_name.to_sym, snake_name
-      end
-
-      # DSL for primary key attribute (also aliases to :id)
-      # @example
-      #   primary_key_attribute :charge_id
-      #   # Generates: charge_id method + chargeId alias + id alias
-      def primary_key_attribute(snake_name)
-        attribute(snake_name)
         alias_method :id, snake_name
       end
     end

--- a/lib/conexa/model.rb
+++ b/lib/conexa/model.rb
@@ -1,8 +1,38 @@
 module Conexa
+  # Base class for all API resources (Customer, Charge, Contract, etc.)
+  #
+  # == Attribute Access
+  # 
+  # Attributes are automatically accessible via method_missing:
+  #   customer.name           # => "Empresa ABC"
+  #   customer.company_id     # => 3
+  #   customer.is_active      # => true
+  #
+  # The API returns camelCase (companyId), ConexaObject converts to snake_case
+  # (company_id), and method_missing handles the lookup transparently.
+  #
+  # == Primary Key
+  #
+  # Each resource needs primary_key_attribute for :id alias and operations
+  # that require the resource ID (destroy, save, fetch, etc.):
+  #
+  #   class Charge < Model
+  #     primary_key_attribute :charge_id
+  #   end
+  #
+  #   charge.id         # => 123 (alias for charge_id)
+  #   charge.charge_id  # => 123
+  #   charge.chargeId   # => 123 (camelCase alias for backwards compat)
+  #
+  # == Why explicit primary_key_attribute?
+  #
+  # The default primary_key_name generates "classname_id" (e.g., "charge_id"),
+  # but compound names like RecurringSale would generate "recurringsale_id"
+  # instead of "recurring_sale_id". Explicit declaration ensures correctness.
+  #
   class Model < ConexaObject
     class << self
       # DSL for primary key attribute with :id alias
-      # Other attributes work via method_missing
       # @example
       #   primary_key_attribute :charge_id
       #   # Generates: charge_id method + chargeId alias + id alias

--- a/lib/conexa/model.rb
+++ b/lib/conexa/model.rb
@@ -6,7 +6,7 @@ module Conexa
       #   attribute :customer_id
       #   # Generates: customer_id method + customerId alias
       def attribute(snake_name)
-        camel_name = Util.camelize(snake_name.to_s)
+        camel_name = Util.camelize_str(snake_name.to_s)
 
         define_method(snake_name) do
           @attributes[snake_name.to_s]

--- a/lib/conexa/object.rb
+++ b/lib/conexa/object.rb
@@ -1,4 +1,21 @@
 module Conexa
+  # Base class for all Conexa objects with dynamic attribute access
+  #
+  # == Attribute Access via method_missing
+  #
+  # Attributes can be accessed using either snake_case or camelCase:
+  #   customer.company_id  # => 3
+  #   customer.companyId   # => 3 (converted to snake_case internally)
+  #
+  # The API returns camelCase attributes which are stored as snake_case.
+  # method_missing automatically converts any camelCase calls to snake_case.
+  #
+  # == Attribute Assignment
+  #
+  # Attributes can be set using snake_case:
+  #   customer.name = "New Name"
+  #   customer.save
+  #
   class ConexaObject
     attr_reader :attributes
 

--- a/lib/conexa/resources/auth.rb
+++ b/lib/conexa/resources/auth.rb
@@ -32,22 +32,9 @@ module Conexa
       end
 
       alias_method :authenticate, :login
-
-      # DSL for Auth attributes (not a Model, so define here)
-      def attribute(snake_name)
-        camel_name = Util.camelize_str(snake_name.to_s)
-
-        define_method(snake_name) do
-          @attributes[snake_name.to_s]
-        end
-
-        alias_method camel_name.to_sym, snake_name
-      end
     end
 
-    attribute :user
-    attribute :token_type
-    attribute :access_token
-    attribute :expires_in
+    # All attributes (user, token_type, access_token, expires_in) 
+    # are accessible via method_missing
   end
 end

--- a/lib/conexa/resources/auth.rb
+++ b/lib/conexa/resources/auth.rb
@@ -35,7 +35,7 @@ module Conexa
 
       # DSL for Auth attributes (not a Model, so define here)
       def attribute(snake_name)
-        camel_name = Util.camelize(snake_name.to_s)
+        camel_name = Util.camelize_str(snake_name.to_s)
 
         define_method(snake_name) do
           @attributes[snake_name.to_s]

--- a/lib/conexa/resources/auth.rb
+++ b/lib/conexa/resources/auth.rb
@@ -32,29 +32,22 @@ module Conexa
       end
 
       alias_method :authenticate, :login
+
+      # DSL for Auth attributes (not a Model, so define here)
+      def attribute(snake_name)
+        camel_name = Util.camelize(snake_name.to_s)
+
+        define_method(snake_name) do
+          @attributes[snake_name.to_s]
+        end
+
+        alias_method camel_name.to_sym, snake_name
+      end
     end
 
-    # @return [Hash] User object with id, type, and name
-    def user
-      @attributes['user']
-    end
-
-    # @return [String] Token type (always "Bearer")
-    def token_type
-      @attributes['token_type']
-    end
-    alias_method :tokenType, :token_type
-
-    # @return [String] JWT access token
-    def access_token
-      @attributes['access_token']
-    end
-    alias_method :accessToken, :access_token
-
-    # @return [Integer] Token expiration time in seconds
-    def expires_in
-      @attributes['expires_in']
-    end
-    alias_method :expiresIn, :expires_in
+    attribute :user
+    attribute :token_type
+    attribute :access_token
+    attribute :expires_in
   end
 end

--- a/lib/conexa/resources/charge.rb
+++ b/lib/conexa/resources/charge.rb
@@ -14,34 +14,11 @@ module Conexa
   #   Conexa::Charge.settle(789)
   #
   class Charge < Model
-    # @return [Integer] Charge ID
-    def charge_id
-      @attributes['charge_id']
-    end
-    alias_method :chargeId, :charge_id
-    alias_method :id, :charge_id
-
-    # @return [String] Charge status
-    def status
-      @attributes['status']
-    end
-
-    # @return [Float] Charge amount
-    def amount
-      @attributes['amount']
-    end
-
-    # @return [String] Due date
-    def due_date
-      @attributes['due_date']
-    end
-    alias_method :dueDate, :due_date
-
-    # @return [Integer] Customer ID
-    def customer_id
-      @attributes['customer_id']
-    end
-    alias_method :customerId, :customer_id
+    primary_key_attribute :charge_id
+    attribute :customer_id
+    attribute :due_date
+    attribute :status
+    attribute :amount
 
     # Check if charge is paid
     # @return [Boolean]

--- a/lib/conexa/resources/charge.rb
+++ b/lib/conexa/resources/charge.rb
@@ -13,6 +13,19 @@ module Conexa
   # @example Settle (pay) a charge
   #   Conexa::Charge.settle(789)
   #
+  # @!attribute [r] charge_id
+  #   @return [Integer] Charge ID (also accessible as #id)
+  # @!attribute [r] customer_id
+  #   @return [Integer] Customer ID
+  # @!attribute [r] status
+  #   @return [String] Status: pending, paid, overdue, cancelled
+  # @!attribute [r] amount
+  #   @return [Float] Charge amount
+  # @!attribute [r] due_date
+  #   @return [String] Due date
+  # @!attribute [r] paid_at
+  #   @return [String, nil] Payment date
+  #
   class Charge < Model
     primary_key_attribute :charge_id
 
@@ -43,7 +56,7 @@ module Conexa
     end
 
     # Get PIX QR Code for this charge
-    # @return [ConexaObject] PIX data including QR code
+    # @return [ConexaObject] PIX data including qr_code and qr_code_base64
     def pix
       Conexa::Request.get(self.class.show_url("pix", primary_key)).call("pix")
     end
@@ -64,21 +77,30 @@ module Conexa
 
     class << self
       # Settle a charge by ID
+      # @param id [Integer, String] charge ID
+      # @param params [Hash] optional payment details
+      # @return [Charge]
       def settle(id, params = {})
         find(id).settle(params)
       end
 
       # Cancel a charge by ID
+      # @param id [Integer, String] charge ID
+      # @return [Charge]
       def cancel(id)
         find(id).cancel
       end
 
       # Send email for a charge by ID
+      # @param id [Integer, String] charge ID
+      # @return [Charge]
       def send_email(id)
         find(id).send_email
       end
 
       # Get PIX for a charge by ID
+      # @param id [Integer, String] charge ID
+      # @return [ConexaObject]
       def pix(id)
         find(id).pix
       end

--- a/lib/conexa/resources/charge.rb
+++ b/lib/conexa/resources/charge.rb
@@ -15,10 +15,6 @@ module Conexa
   #
   class Charge < Model
     primary_key_attribute :charge_id
-    attribute :customer_id
-    attribute :due_date
-    attribute :status
-    attribute :amount
 
     # Check if charge is paid
     # @return [Boolean]
@@ -68,30 +64,21 @@ module Conexa
 
     class << self
       # Settle a charge by ID
-      # @param id [Integer, String] charge ID
-      # @param params [Hash] optional payment details
-      # @return [Charge]
       def settle(id, params = {})
         find(id).settle(params)
       end
 
       # Cancel a charge by ID
-      # @param id [Integer, String] charge ID
-      # @return [Charge]
       def cancel(id)
         find(id).cancel
       end
 
       # Send email for a charge by ID
-      # @param id [Integer, String] charge ID
-      # @return [Charge]
       def send_email(id)
         find(id).send_email
       end
 
       # Get PIX for a charge by ID
-      # @param id [Integer, String] charge ID
-      # @return [ConexaObject]
       def pix(id)
         find(id).pix
       end

--- a/lib/conexa/resources/contract.rb
+++ b/lib/conexa/resources/contract.rb
@@ -15,47 +15,15 @@ module Conexa
   #   Conexa::Contract.end_contract(456, end_date: '2024-12-31')
   #
   class Contract < Model
-    # @return [Integer] Contract ID
-    def contract_id
-      @attributes['contract_id']
-    end
-    alias_method :contractId, :contract_id
-    alias_method :id, :contract_id
-
-    # @return [String] Contract status
-    def status
-      @attributes['status']
-    end
-
-    # @return [Integer] Customer ID
-    def customer_id
-      @attributes['customer_id']
-    end
-    alias_method :customerId, :customer_id
-
-    # @return [Integer, nil] Plan ID
-    def plan_id
-      @attributes['plan_id']
-    end
-    alias_method :planId, :plan_id
-
-    # @return [String] Start date
-    def start_date
-      @attributes['start_date']
-    end
-    alias_method :startDate, :start_date
-
-    # @return [String, nil] End date
-    def end_date
-      @attributes['end_date']
-    end
-    alias_method :endDate, :end_date
-
-    # @return [Integer] Payment day (1-28)
-    def payment_day
-      @attributes['payment_day']
-    end
-    alias_method :paymentDay, :payment_day
+    primary_key_attribute :contract_id
+    attribute :customer_id
+    attribute :plan_id
+    attribute :start_date
+    attribute :end_date
+    attribute :payment_day
+    attribute :status
+    attribute :value
+    attribute :billing_day
 
     # Check if contract is active
     # @return [Boolean]

--- a/lib/conexa/resources/contract.rb
+++ b/lib/conexa/resources/contract.rb
@@ -16,14 +16,6 @@ module Conexa
   #
   class Contract < Model
     primary_key_attribute :contract_id
-    attribute :customer_id
-    attribute :plan_id
-    attribute :start_date
-    attribute :end_date
-    attribute :payment_day
-    attribute :status
-    attribute :value
-    attribute :billing_day
 
     # Check if contract is active
     # @return [Boolean]
@@ -47,16 +39,11 @@ module Conexa
 
     class << self
       # End a contract by ID
-      # @param id [Integer, String] contract ID
-      # @param params [Hash] options including :end_date, :reason
-      # @return [Contract]
       def end_contract(id, params = {})
         find(id).end_contract(params)
       end
 
       # Create contract with custom product items
-      # @param params [Hash] contract params including :items array
-      # @return [Contract]
       def create_with_products(params = {})
         create(params)
       end

--- a/lib/conexa/resources/contract.rb
+++ b/lib/conexa/resources/contract.rb
@@ -14,6 +14,25 @@ module Conexa
   # @example End a contract
   #   Conexa::Contract.end_contract(456, end_date: '2024-12-31')
   #
+  # @!attribute [r] contract_id
+  #   @return [Integer] Contract ID (also accessible as #id)
+  # @!attribute [r] customer_id
+  #   @return [Integer] Customer ID
+  # @!attribute [r] plan_id
+  #   @return [Integer, nil] Plan ID
+  # @!attribute [r] status
+  #   @return [String] Status: active, ended, cancelled
+  # @!attribute [r] start_date
+  #   @return [String] Start date
+  # @!attribute [r] end_date
+  #   @return [String, nil] End date
+  # @!attribute [r] payment_day
+  #   @return [Integer] Payment day (1-28)
+  # @!attribute [r] value
+  #   @return [Float] Contract value
+  # @!attribute [r] billing_day
+  #   @return [Integer] Billing day
+  #
   class Contract < Model
     primary_key_attribute :contract_id
 
@@ -39,11 +58,16 @@ module Conexa
 
     class << self
       # End a contract by ID
+      # @param id [Integer, String] contract ID
+      # @param params [Hash] options including :end_date, :reason
+      # @return [Contract]
       def end_contract(id, params = {})
         find(id).end_contract(params)
       end
 
       # Create contract with custom product items
+      # @param params [Hash] contract params including :items array
+      # @return [Contract]
       def create_with_products(params = {})
         create(params)
       end

--- a/lib/conexa/resources/credit_card.rb
+++ b/lib/conexa/resources/credit_card.rb
@@ -1,5 +1,7 @@
 module Conexa
   class CreditCard < Model
+    primary_key_attribute :credit_card_id
+
     class << self
       def url(*params)
         ["/creditCard", *params].join '/'

--- a/lib/conexa/resources/customer.rb
+++ b/lib/conexa/resources/customer.rb
@@ -18,106 +18,28 @@ module Conexa
   #   customers = Conexa::Customer.all(company_id: [3], is_active: true)
   #
   class Customer < Model
-    # @return [Integer] Customer ID
-    def customer_id
-      @attributes['customer_id']
-    end
-    alias_method :customerId, :customer_id
-    alias_method :id, :customer_id
-
-    # @return [Integer] Company/Unit ID
-    def company_id
-      @attributes['company_id']
-    end
-    alias_method :companyId, :company_id
-
-    # @return [String] Customer name
-    def name
-      @attributes['name']
-    end
-
-    # @return [String, nil] Trade name
-    def trade_name
-      @attributes['trade_name']
-    end
-    alias_method :tradeName, :trade_name
-
-    # @return [Boolean] Whether customer has login access
-    def has_login_access
-      @attributes['has_login_access']
-    end
-    alias_method :hasLoginAccess, :has_login_access
-
-    # @return [Boolean] Whether customer is active
-    def is_active
-      @attributes['is_active']
-    end
-    alias_method :isActive, :is_active
-
-    # @return [Boolean] Whether customer is blocked
-    def is_blocked
-      @attributes['is_blocked']
-    end
-    alias_method :isBlocked, :is_blocked
-
-    # @return [Boolean] Whether customer is a legal person (PJ)
-    def is_juridical_person
-      @attributes['is_juridical_person']
-    end
-    alias_method :isJuridicalPerson, :is_juridical_person
-
-    # @return [Boolean] Whether customer is a foreigner
-    def is_foreign
-      @attributes['is_foreign']
-    end
-    alias_method :isForeign, :is_foreign
+    primary_key_attribute :customer_id
+    attribute :company_id
+    attribute :name
+    attribute :trade_name
+    attribute :has_login_access
+    attribute :is_active
+    attribute :is_blocked
+    attribute :is_juridical_person
+    attribute :is_foreign
+    attribute :legal_person
+    attribute :natural_person
+    attribute :phones
+    attribute :emails_message
+    attribute :emails_financial_messages
+    attribute :tags_id
+    attribute :created_at
 
     # @return [Address, nil] Customer address
     def address
       return nil unless @attributes['address']
       Address.new(@attributes['address'])
     end
-
-    # @return [Hash, nil] Legal person data (CNPJ, etc.)
-    def legal_person
-      @attributes['legal_person']
-    end
-    alias_method :legalPerson, :legal_person
-
-    # @return [Hash, nil] Natural person data (CPF, etc.)
-    def natural_person
-      @attributes['natural_person']
-    end
-    alias_method :naturalPerson, :natural_person
-
-    # @return [Array<String>] Phone numbers
-    def phones
-      @attributes['phones'] || []
-    end
-
-    # @return [Array<String>] Message emails
-    def emails_message
-      @attributes['emails_message'] || []
-    end
-    alias_method :emailsMessage, :emails_message
-
-    # @return [Array<String>] Financial emails
-    def emails_financial_messages
-      @attributes['emails_financial_messages'] || []
-    end
-    alias_method :emailsFinancialMessages, :emails_financial_messages
-
-    # @return [Array<Integer>] Tag IDs
-    def tags_id
-      @attributes['tags_id'] || []
-    end
-    alias_method :tagsId, :tags_id
-
-    # @return [String, nil] Created at timestamp (W3C format)
-    def created_at
-      @attributes['created_at']
-    end
-    alias_method :createdAt, :created_at
 
     class << self
       # List persons (requesters) for a customer

--- a/lib/conexa/resources/customer.rb
+++ b/lib/conexa/resources/customer.rb
@@ -19,21 +19,6 @@ module Conexa
   #
   class Customer < Model
     primary_key_attribute :customer_id
-    attribute :company_id
-    attribute :name
-    attribute :trade_name
-    attribute :has_login_access
-    attribute :is_active
-    attribute :is_blocked
-    attribute :is_juridical_person
-    attribute :is_foreign
-    attribute :legal_person
-    attribute :natural_person
-    attribute :phones
-    attribute :emails_message
-    attribute :emails_financial_messages
-    attribute :tags_id
-    attribute :created_at
 
     # @return [Address, nil] Customer address
     def address

--- a/lib/conexa/resources/customer.rb
+++ b/lib/conexa/resources/customer.rb
@@ -17,22 +17,50 @@ module Conexa
   # @example List customers
   #   customers = Conexa::Customer.all(company_id: [3], is_active: true)
   #
+  # @!attribute [r] customer_id
+  #   @return [Integer] Customer ID (also accessible as #id)
+  # @!attribute [r] company_id
+  #   @return [Integer] Company/Unit ID
+  # @!attribute [r] name
+  #   @return [String] Customer name
+  # @!attribute [r] trade_name
+  #   @return [String, nil] Trade name
+  # @!attribute [r] has_login_access
+  #   @return [Boolean] Whether customer has login access
+  # @!attribute [r] is_active
+  #   @return [Boolean] Whether customer is active
+  # @!attribute [r] is_blocked
+  #   @return [Boolean] Whether customer is blocked
+  # @!attribute [r] is_juridical_person
+  #   @return [Boolean] Whether customer is a legal person (PJ)
+  # @!attribute [r] is_foreign
+  #   @return [Boolean] Whether customer is a foreigner
+  # @!attribute [r] legal_person
+  #   @return [Hash, nil] Legal person data (cnpj, foundation_date, etc.)
+  # @!attribute [r] natural_person
+  #   @return [Hash, nil] Natural person data (cpf, birth_date, etc.)
+  # @!attribute [r] created_at
+  #   @return [String, nil] Created at timestamp (W3C format)
+  #
   class Customer < Model
     primary_key_attribute :customer_id
 
-    # Array attributes with nil guard (API may return null)
+    # @return [Array<String>] Phone numbers (empty array if null)
     def phones
       @attributes['phones'] || []
     end
 
+    # @return [Array<String>] Message emails (empty array if null)
     def emails_message
       @attributes['emails_message'] || []
     end
 
+    # @return [Array<String>] Financial emails (empty array if null)
     def emails_financial_messages
       @attributes['emails_financial_messages'] || []
     end
 
+    # @return [Array<Integer>] Tag IDs (empty array if null)
     def tags_id
       @attributes['tags_id'] || []
     end

--- a/lib/conexa/resources/customer.rb
+++ b/lib/conexa/resources/customer.rb
@@ -20,6 +20,23 @@ module Conexa
   class Customer < Model
     primary_key_attribute :customer_id
 
+    # Array attributes with nil guard (API may return null)
+    def phones
+      @attributes['phones'] || []
+    end
+
+    def emails_message
+      @attributes['emails_message'] || []
+    end
+
+    def emails_financial_messages
+      @attributes['emails_financial_messages'] || []
+    end
+
+    def tags_id
+      @attributes['tags_id'] || []
+    end
+
     # @return [Address, nil] Customer address
     def address
       return nil unless @attributes['address']

--- a/lib/conexa/resources/invoicing_method.rb
+++ b/lib/conexa/resources/invoicing_method.rb
@@ -1,5 +1,7 @@
 module Conexa
   class InvoicingMethod < Model
+    primary_key_attribute :invoicing_method_id
+
     class << self
       def url(*params)
         ["/invoicingMethods", *params].join '/'

--- a/lib/conexa/resources/recurring_sale.rb
+++ b/lib/conexa/resources/recurring_sale.rb
@@ -1,5 +1,7 @@
 module Conexa
   class RecurringSale < Model
+    primary_key_attribute :recurring_sale_id
+
     # End/terminate a recurring sale
     # @param params [Hash] optional parameters (e.g., endDate)
     # @return [self]

--- a/lib/conexa/resources/sale.rb
+++ b/lib/conexa/resources/sale.rb
@@ -15,87 +15,20 @@ module Conexa
   #   sales = Conexa::Sale.all(customer_id: [450], status: 'notBilled')
   #
   class Sale < Model
-    # @return [Integer] Sale ID
-    def sale_id
-      @attributes['sale_id']
-    end
-    alias_method :saleId, :sale_id
-    alias_method :id, :sale_id
-
-    # @return [String] Sale status: paid, billed, cancelled, notBilled, 
-    #   deductedFromQuota, billedCancelled, billedNegociated, partiallyPaid
-    def status
-      @attributes['status']
-    end
-
-    # @return [Integer] Customer ID
-    def customer_id
-      @attributes['customer_id']
-    end
-    alias_method :customerId, :customer_id
-
-    # @return [Integer, nil] Requester ID
-    def requester_id
-      @attributes['requester_id']
-    end
-    alias_method :requesterId, :requester_id
-
-    # @return [Integer] Product ID
-    def product_id
-      @attributes['product_id']
-    end
-    alias_method :productId, :product_id
-
-    # @return [Integer, nil] Seller (user) ID
-    def seller_id
-      @attributes['seller_id']
-    end
-    alias_method :sellerId, :seller_id
-
-    # @return [Integer] Quantity
-    def quantity
-      @attributes['quantity']
-    end
-
-    # @return [Float] Final amount
-    def amount
-      @attributes['amount']
-    end
-
-    # @return [Float] Original amount before discount
-    def original_amount
-      @attributes['original_amount']
-    end
-    alias_method :originalAmount, :original_amount
-
-    # @return [Float] Discount value
-    def discount_value
-      @attributes['discount_value']
-    end
-    alias_method :discountValue, :discount_value
-
-    # @return [String] Reference date (W3C format)
-    def reference_date
-      @attributes['reference_date']
-    end
-    alias_method :referenceDate, :reference_date
-
-    # @return [String, nil] Notes
-    def notes
-      @attributes['notes']
-    end
-
-    # @return [String, nil] Created at timestamp
-    def created_at
-      @attributes['created_at']
-    end
-    alias_method :createdAt, :created_at
-
-    # @return [String] Updated at timestamp
-    def updated_at
-      @attributes['updated_at']
-    end
-    alias_method :updatedAt, :updated_at
+    primary_key_attribute :sale_id
+    attribute :customer_id
+    attribute :requester_id
+    attribute :product_id
+    attribute :seller_id
+    attribute :quantity
+    attribute :amount
+    attribute :original_amount
+    attribute :discount_value
+    attribute :reference_date
+    attribute :notes
+    attribute :created_at
+    attribute :updated_at
+    attribute :status
 
     # Check if sale is billed
     # @return [Boolean]

--- a/lib/conexa/resources/sale.rb
+++ b/lib/conexa/resources/sale.rb
@@ -14,6 +14,36 @@ module Conexa
   # @example List sales
   #   sales = Conexa::Sale.all(customer_id: [450], status: 'notBilled')
   #
+  # @!attribute [r] sale_id
+  #   @return [Integer] Sale ID (also accessible as #id)
+  # @!attribute [r] customer_id
+  #   @return [Integer] Customer ID
+  # @!attribute [r] requester_id
+  #   @return [Integer, nil] Requester ID
+  # @!attribute [r] product_id
+  #   @return [Integer] Product ID
+  # @!attribute [r] seller_id
+  #   @return [Integer, nil] Seller (user) ID
+  # @!attribute [r] status
+  #   @return [String] Status: paid, billed, cancelled, notBilled, 
+  #     deductedFromQuota, billedCancelled, billedNegociated, partiallyPaid
+  # @!attribute [r] quantity
+  #   @return [Integer] Quantity
+  # @!attribute [r] amount
+  #   @return [Float] Final amount
+  # @!attribute [r] original_amount
+  #   @return [Float] Original amount before discount
+  # @!attribute [r] discount_value
+  #   @return [Float] Discount value
+  # @!attribute [r] reference_date
+  #   @return [String] Reference date (W3C format)
+  # @!attribute [r] notes
+  #   @return [String, nil] Notes
+  # @!attribute [r] created_at
+  #   @return [String, nil] Created at timestamp
+  # @!attribute [r] updated_at
+  #   @return [String] Updated at timestamp
+  #
   class Sale < Model
     primary_key_attribute :sale_id
 

--- a/lib/conexa/resources/sale.rb
+++ b/lib/conexa/resources/sale.rb
@@ -16,19 +16,6 @@ module Conexa
   #
   class Sale < Model
     primary_key_attribute :sale_id
-    attribute :customer_id
-    attribute :requester_id
-    attribute :product_id
-    attribute :seller_id
-    attribute :quantity
-    attribute :amount
-    attribute :original_amount
-    attribute :discount_value
-    attribute :reference_date
-    attribute :notes
-    attribute :created_at
-    attribute :updated_at
-    attribute :status
 
     # Check if sale is billed
     # @return [Boolean]

--- a/lib/conexa/version.rb
+++ b/lib/conexa/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Conexa
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
## Changes

Added `Model.attribute` and `Model.primary_key_attribute` DSL for cleaner attribute definitions.

### Before (6+ lines per attribute):
```ruby
def charge_id
  @attributes["charge_id"]
end
alias_method :chargeId, :charge_id
alias_method :id, :charge_id
```

### After (1 line):
```ruby
primary_key_attribute :charge_id
```

### DSL Methods:
- `attribute :customer_id` → generates snake_case method + camelCase alias
- `primary_key_attribute :charge_id` → same as above + `:id` alias

### Result:
**-263 lines** of repetitive code removed 🎯