### PR TITLE
feat: default new pagination, next_page & v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-03-30
+
+### Added
+- `Result#next_page` — automatically fetches the next page preserving original filter params
+- `Result#has_next?` — convenience method to check if more pages are available
+- Pagination migration guide added to README (EN/PT-BR) and REFERENCE.md
+
+### Changed
+- **Breaking**: Default pagination is now `limit: 100, offset: 0` (was `page: 1, size: 100`)
+  - Calling `.all` or `.find_by` without pagination params now uses the new model
+  - Legacy `page`/`size` is only used when explicitly passed (emits deprecation warning)
+
 ## [0.0.9] - 2026-03-30
 
 ### Added
@@ -87,7 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Charge with settle and PIX methods
 - Pagination support
 
-[Unreleased]: https://github.com/guilhermegazzinelli/conexa-ruby/compare/v0.0.9...HEAD
+[Unreleased]: https://github.com/guilhermegazzinelli/conexa-ruby/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/guilhermegazzinelli/conexa-ruby/compare/v0.0.9...v0.1.0
 [0.0.9]: https://github.com/guilhermegazzinelli/conexa-ruby/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/guilhermegazzinelli/conexa-ruby/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/guilhermegazzinelli/conexa-ruby/compare/v0.0.6...v0.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-03-30
+## [0.1.0] - 2026-03-31
 
 ### Added
 - `Result#next_page` — automatically fetches the next page preserving original filter params
 - `Result#has_next?` — convenience method to check if more pages are available
 - Pagination migration guide added to README (EN/PT-BR) and REFERENCE.md
+- Validation for `limit` (must be positive integer) and `offset` (must be non-negative integer) parameters
+- `frozen_string_literal: true` pragma added to all Ruby source files
+- ActiveSupport compatibility guard for `blank?`/`present?` monkey-patches
+- `respond_to_missing?` implemented in `ConexaObject` and `Result` (Ruby best practice)
+- Integration tests for all new API v2 resources (24 specs)
+- Unit tests for pagination validation and `class_name` camelCase preservation (6 specs)
+- Total: 502 specs
 
 ### Changed
 - **Breaking**: Default pagination is now `limit: 100, offset: 0` (was `page: 1, size: 100`)
   - Calling `.all` or `.find_by` without pagination params now uses the new model
   - Legacy `page`/`size` is only used when explicitly passed (emits deprecation warning)
+- `Model.all` simplified — delegates directly to `find_by` without double param extraction
+- `Model.class_name` now returns proper lowerCamelCase (e.g. `recurringSale` instead of `recurringsale`)
+- `OrderCommom` renamed to `OrderCommon` (backwards-compatible alias kept)
+- `Bill#save` now raises `NoMethodError` with descriptive message
+- README updated: all examples now use correct method names (`.all`, `.find`, `.destroy`)
+- README error handling section rewritten with actual exception classes
+
+### Fixed
+- **Concurrency bug**: `DEFAULT_HEADERS` constant was mutated on every request; now uses `.dup`
+- **Boolean false bug**: `Result#method_missing` skipped `false` attribute values due to `||` operator
+- **ValidationError crash**: undefined variable `error` in block scope — fixed to use `msg`
+- **TokenManager typo**: `ShiConexa` → `Conexa` in credentials handling
+- **Singularize**: `SINGULARS` patterns were stored as strings, never used as regex — rewritten with proper `Regexp` objects
+- **Deep copy**: `Result#next_page` now uses `Marshal.load(Marshal.dump(...))` to prevent param mutation between pages
+- Stray `-` character removed from `util.rb`
+- Removed dead code: `Hash#except_nested` monkey-patch, commented-out `to_s` method
 
 ## [0.0.9] - 2026-03-30
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conexa (0.0.8)
+    conexa (0.1.0)
       jwt
       multi_json
       rest-client

--- a/README.md
+++ b/README.md
@@ -378,14 +378,22 @@ result = Conexa::Customer.list(limit: 50)
 result.data                    # Array of customers
 result.pagination.limit        # => 50
 result.pagination.offset       # => 0
-result.pagination.has_next     # => true/false
+result.has_next?               # => true/false
 
-# Iterate through all pages
+# Iterate through all pages using next_page
+result = Conexa::Customer.list(limit: 50)
+loop do
+  result.data.each { |customer| process(customer) }
+  break unless result.has_next?
+  result = result.next_page
+end
+
+# Or manually with offset
 offset = 0
 loop do
   result = Conexa::Customer.list(limit: 50, offset: offset)
   result.data.each { |customer| process(customer) }
-  break unless result.pagination.has_next
+  break unless result.has_next?
   offset += 50
 end
 ```
@@ -442,13 +450,12 @@ loop do
   page += 1
 end
 
-# AFTER (new)
-offset = 0
+# AFTER (new — using next_page)
+result = Conexa::Customer.list(limit: 100)
 loop do
-  result = Conexa::Customer.list(limit: 100, offset: offset)
   result.data.each { |c| process(c) }
-  break unless result.pagination.has_next
-  offset += 100
+  break unless result.has_next?
+  result = result.next_page
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Conexa.configure do |config|
 end
 
 # List customers
-customers = Conexa::Customer.list
+customers = Conexa::Customer.all
 customers.data.each do |customer|
   puts "#{customer.customer_id}: #{customer.name}"
 end
 
 # Get a specific customer
-customer = Conexa::Customer.retrieve(127)
+customer = Conexa::Customer.find(127)
 puts customer.name
 puts customer.address.city
 ```
@@ -110,7 +110,7 @@ customer = Conexa::Customer.create(
 )
 
 # Retrieve customer
-customer = Conexa::Customer.retrieve(127)
+customer = Conexa::Customer.find(127)
 customer.name           # => "Empresa ABC Ltda"
 customer.company_id     # => 3
 customer.is_active      # => true
@@ -118,10 +118,13 @@ customer.address.city   # => "Campinas"
 customer.legal_person['cnpj']  # => "99.557.155/0001-90"
 
 # Update customer
-Conexa::Customer.update(127, name: 'New Name', cell_number: '11888887777')
+customer = Conexa::Customer.find(127)
+customer.name = 'New Name'
+customer.cell_number = '11888887777'
+customer.save
 
 # List customers with filters (new pagination)
-customers = Conexa::Customer.list(
+customers = Conexa::Customer.all(
   company_id: [3],
   is_active: true,
   limit: 20
@@ -152,7 +155,7 @@ contract = Conexa::Contract.create_with_products(
 )
 
 # Retrieve contract
-contract = Conexa::Contract.retrieve(456)
+contract = Conexa::Contract.find(456)
 
 # Cancel contract
 Conexa::Contract.cancel(456, cancel_date: '2024-12-31')
@@ -174,13 +177,13 @@ sale = Conexa::Sale.create(
 puts sale.id  # => 188481
 
 # Retrieve sale
-sale = Conexa::Sale.retrieve(188510)
+sale = Conexa::Sale.find(188510)
 sale.status         # => "notBilled"
 sale.amount         # => 80.99
 sale.discount_value # => 69.21
 
 # List sales
-sales = Conexa::Sale.list(
+sales = Conexa::Sale.all(
   customer_id: [450, 216],
   status: 'notBilled',
   date_from: '2024-01-01',
@@ -190,10 +193,13 @@ sales = Conexa::Sale.list(
 )
 
 # Update sale
-Conexa::Sale.update(188510, quantity: 2, amount: 150.00)
+sale = Conexa::Sale.find(188510)
+sale.quantity = 2
+sale.amount = 150.00
+sale.save
 
 # Delete sale (only if not billed)
-Conexa::Sale.delete(188510)
+Conexa::Sale.destroy(188510)
 ```
 
 ### Recurring Sale
@@ -208,20 +214,20 @@ recurring = Conexa::RecurringSale.create(
 )
 
 # List recurring sales for a contract
-Conexa::RecurringSale.list(contract_id: 456)
+Conexa::RecurringSale.all(contract_id: 456)
 ```
 
 ### Charge
 
 ```ruby
 # Retrieve charge
-charge = Conexa::Charge.retrieve(789)
+charge = Conexa::Charge.find(789)
 charge.status     # => "paid"
 charge.amount     # => 299.90
 charge.due_date   # => "2024-02-10"
 
 # List charges
-charges = Conexa::Charge.list(
+charges = Conexa::Charge.all(
   customer_id: [127],
   status: 'pending',
   due_date_from: '2024-01-01',
@@ -239,10 +245,10 @@ Conexa::Charge.send_email(789)
 
 ```ruby
 # Retrieve bill
-bill = Conexa::Bill.retrieve(101)
+bill = Conexa::Bill.find(101)
 
 # List bills
-bills = Conexa::Bill.list(
+bills = Conexa::Bill.all(
   customer_id: [127],
   page: 1,
   size: 50
@@ -253,10 +259,10 @@ bills = Conexa::Bill.list(
 
 ```ruby
 # List plans
-plans = Conexa::Plan.list(company_id: [3])
+plans = Conexa::Plan.all(company_id: [3])
 
 # Retrieve plan
-plan = Conexa::Plan.retrieve(5)
+plan = Conexa::Plan.find(5)
 plan.name   # => "Plano Básico"
 plan.price  # => 99.90
 ```
@@ -265,66 +271,66 @@ plan.price  # => 99.90
 
 ```ruby
 # List products
-products = Conexa::Product.list(company_id: [3], limit: 50)
+products = Conexa::Product.all(company_id: [3], limit: 50)
 
 # Retrieve product
-product = Conexa::Product.retrieve(101)
+product = Conexa::Product.find(101)
 
 # Create product
 product = Conexa::Product.create(name: 'Novo Produto', company_id: 3)
 
 # Delete product
-Conexa::Product.delete(101)
+Conexa::Product.destroy(101)
 ```
 
 ### Receiving Method
 
 ```ruby
-methods = Conexa::ReceivingMethod.list(limit: 50)
-method = Conexa::ReceivingMethod.retrieve(11)
+methods = Conexa::ReceivingMethod.all(limit: 50)
+method = Conexa::ReceivingMethod.find(11)
 method.name  # => "Cartão de Crédito"
 ```
 
 ### Payment Method
 
 ```ruby
-methods = Conexa::PaymentMethod.list(limit: 50)
-method = Conexa::PaymentMethod.retrieve(2)
+methods = Conexa::PaymentMethod.all(limit: 50)
+method = Conexa::PaymentMethod.find(2)
 ```
 
 ### Bill Category / Subcategory
 
 ```ruby
-categories = Conexa::BillCategory.list(limit: 50)
-subcategories = Conexa::BillSubcategory.list(limit: 50)
+categories = Conexa::BillCategory.all(limit: 50)
+subcategories = Conexa::BillSubcategory.all(limit: 50)
 ```
 
 ### Cost Center
 
 ```ruby
-centers = Conexa::CostCenter.list(limit: 50)
-center = Conexa::CostCenter.retrieve(11)
+centers = Conexa::CostCenter.all(limit: 50)
+center = Conexa::CostCenter.find(11)
 ```
 
 ### Account
 
 ```ruby
-accounts = Conexa::Account.list(limit: 50)
-account = Conexa::Account.retrieve(23)
+accounts = Conexa::Account.all(limit: 50)
+account = Conexa::Account.find(23)
 ```
 
 ### Service Category
 
 ```ruby
-categories = Conexa::ServiceCategory.list(limit: 50)
-category = Conexa::ServiceCategory.retrieve(1)
+categories = Conexa::ServiceCategory.all(limit: 50)
+category = Conexa::ServiceCategory.find(1)
 ```
 
 ### Room Booking
 
 ```ruby
 # List bookings
-bookings = Conexa::RoomBooking.list(limit: 20)
+bookings = Conexa::RoomBooking.all(limit: 20)
 
 # Create booking
 booking = Conexa::RoomBooking.create(room_id: 5, customer_id: 127)
@@ -350,20 +356,20 @@ card = Conexa::CreditCard.create(
 )
 
 # List customer's cards
-cards = Conexa::CreditCard.list(customer_id: 127)
+cards = Conexa::CreditCard.all(customer_id: 127)
 
 # Delete card
-Conexa::CreditCard.delete(card_id)
+Conexa::CreditCard.destroy(card_id)
 ```
 
 ### Company (Unit)
 
 ```ruby
 # List companies/units
-companies = Conexa::Company.list
+companies = Conexa::Company.all
 
 # Retrieve company
-company = Conexa::Company.retrieve(3)
+company = Conexa::Company.find(3)
 company.name      # => "Matriz"
 company.document  # => "12.345.678/0001-90"
 ```
@@ -373,7 +379,7 @@ company.document  # => "12.345.678/0001-90"
 ### New Pagination (recommended) — `limit`/`offset`/`hasNext`
 
 ```ruby
-result = Conexa::Customer.list(limit: 50)
+result = Conexa::Customer.all(limit: 50)
 
 result.data                    # Array of customers
 result.pagination.limit        # => 50
@@ -381,7 +387,7 @@ result.pagination.offset       # => 0
 result.has_next?               # => true/false
 
 # Iterate through all pages using next_page
-result = Conexa::Customer.list(limit: 50)
+result = Conexa::Customer.all(limit: 50)
 loop do
   result.data.each { |customer| process(customer) }
   break unless result.has_next?
@@ -391,7 +397,7 @@ end
 # Or manually with offset
 offset = 0
 loop do
-  result = Conexa::Customer.list(limit: 50, offset: offset)
+  result = Conexa::Customer.all(limit: 50, offset: offset)
   result.data.each { |customer| process(customer) }
   break unless result.has_next?
   offset += 50
@@ -402,7 +408,7 @@ end
 
 ```ruby
 # Still works but emits a deprecation warning
-result = Conexa::Customer.list(page: 1, size: 20)
+result = Conexa::Customer.all(page: 1, size: 20)
 result.pagination.current_page    # => 1
 result.pagination.total_pages     # => 10
 ```
@@ -415,12 +421,12 @@ The legacy `page`/`size` pagination is deprecated and will be removed on **2026-
 
 ```ruby
 # BEFORE (legacy — deprecated)
-result = Conexa::Customer.list(page: 1, size: 50)
-result = Conexa::Customer.list(page: 2, size: 50)
+result = Conexa::Customer.all(page: 1, size: 50)
+result = Conexa::Customer.all(page: 2, size: 50)
 
 # AFTER (new)
-result = Conexa::Customer.list(limit: 50)               # offset defaults to 0
-result = Conexa::Customer.list(limit: 50, offset: 50)   # second page
+result = Conexa::Customer.all(limit: 50)               # offset defaults to 0
+result = Conexa::Customer.all(limit: 50, offset: 50)   # second page
 ```
 
 **Conversion formula:** `offset = (page - 1) * size`
@@ -444,14 +450,14 @@ result.pagination.has_next   # => true/false
 # BEFORE (legacy)
 page = 1
 loop do
-  result = Conexa::Customer.list(page: page, size: 100)
+  result = Conexa::Customer.all(page: page, size: 100)
   break if result.empty?
   result.data.each { |c| process(c) }
   page += 1
 end
 
 # AFTER (new — using next_page)
-result = Conexa::Customer.list(limit: 100)
+result = Conexa::Customer.all(limit: 100)
 loop do
   result.data.each { |c| process(c) }
   break unless result.has_next?
@@ -488,29 +494,22 @@ begin
   customer = Conexa::Customer.create(name: '')
 rescue Conexa::ValidationError => e
   # Field validation errors (400)
-  e.errors.each do |error|
-    puts "#{error['field']}: #{error['messages'].join(', ')}"
-  end
-rescue Conexa::AuthenticationError => e
-  # Authentication required (401)
   puts e.message
-rescue Conexa::AuthorizationError => e
-  # Not authorized (403)
-  puts e.message
-rescue Conexa::NotFoundError => e
+rescue Conexa::NotFound => e
   # Resource not found (404)
   puts e.message
-rescue Conexa::UnprocessableError => e
-  # Business logic error (422)
-  e.errors.each do |error|
-    puts "#{error['code']}: #{error['message']}"
-  end
-rescue Conexa::RateLimitError => e
-  # Too many requests (429)
-  puts "Rate limit exceeded. Retry after #{e.retry_after} seconds"
-rescue Conexa::ApiError => e
-  # Generic API error
-  puts "Error #{e.status}: #{e.message}"
+rescue Conexa::ResponseError => e
+  # API response error (4xx/5xx)
+  puts e.message
+rescue Conexa::RequestError => e
+  # Request-level error (invalid params, etc.)
+  puts e.message
+rescue Conexa::ConnectionError => e
+  # Network/connection error
+  puts e.message
+rescue Conexa::ConexaError => e
+  # Generic Conexa error (catch-all)
+  puts e.message
 end
 ```
 

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -309,14 +309,22 @@ resultado = Conexa::Customer.all(limit: 50)
 resultado.data                    # Array de clientes
 resultado.pagination.limit        # => 50
 resultado.pagination.offset       # => 0
-resultado.pagination.has_next     # => true/false
+resultado.has_next?               # => true/false
 
-# Iterar por todas as páginas
+# Iterar por todas as páginas usando next_page
+resultado = Conexa::Customer.all(limit: 50)
+loop do
+  resultado.data.each { |cliente| processa(cliente) }
+  break unless resultado.has_next?
+  resultado = resultado.next_page
+end
+
+# Ou manualmente com offset
 offset = 0
 loop do
   resultado = Conexa::Customer.all(limit: 50, offset: offset)
   resultado.data.each { |cliente| processa(cliente) }
-  break unless resultado.pagination.has_next
+  break unless resultado.has_next?
   offset += 50
 end
 ```
@@ -364,13 +372,12 @@ loop do
   pagina += 1
 end
 
-# DEPOIS (novo)
-offset = 0
+# DEPOIS (novo — usando next_page)
+resultado = Conexa::Customer.all(limit: 100)
 loop do
-  resultado = Conexa::Customer.all(limit: 100, offset: offset)
   resultado.data.each { |c| processa(c) }
-  break unless resultado.pagination.has_next
-  offset += 100
+  break unless resultado.has_next?
+  resultado = resultado.next_page
 end
 ```
 

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -73,25 +73,27 @@ Cada recurso segue um conjunto consistente de padrões de métodos:
 
 ### Paginação
 
-A API utiliza os parâmetros `page` e `size` para paginação com os seguintes valores padrão:
-
-- **page**: Número da página atual (padrão: `1`)
-- **size**: Quantidade de itens por página (padrão: `100`)
+A gem utiliza por padrão `limit: 100, offset: 0` (nova paginação). O modelo legado `page`/`size` ainda funciona mas emite um aviso de depreciação.
 
 #### Chamando com Paginação
 
 ```ruby
-# Paginação padrão (página 1, 100 itens)
+# Paginação padrão (limit: 100, offset: 0)
 Conexa::Customer.all
 
-# Argumentos posicionais (página, tamanho)
-Conexa::Customer.all(2, 50)  # página 2, 50 itens por página
+# Com limite customizado
+Conexa::Customer.all(limit: 50)
 
-# Parâmetros nomeados
-Conexa::Customer.all(page: 3, size: 25)
+# Com offset
+Conexa::Customer.all(limit: 50, offset: 100)
 
-# Usando o alias `where`
-Conexa::Customer.where(page: 2, size: 10)
+# Iteração automática com next_page
+resultado = Conexa::Customer.all(limit: 50)
+loop do
+  resultado.data.each { |cliente| processa(cliente) }
+  break unless resultado.has_next?
+  resultado = resultado.next_page
+end
 ```
 
 ### Objeto Result

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -32,7 +32,7 @@ Conexa is a Brazilian SaaS platform for **recurring billing**, **subscription ma
 
 ```ruby
 # Gemfile
-gem 'conexa', '~> 0.0.9'
+gem 'conexa', '~> 0.1.0'
 
 # Or install directly
 gem install conexa
@@ -1034,7 +1034,7 @@ person.destroy
 
 #### New Pagination (recommended) — `limit`/`offset`/`hasNext`
 
-All `#all` and `#find_by` methods support the new pagination when `limit:` is passed:
+All `#all` and `#find_by` methods use `limit`/`offset` by default. When no pagination params are passed, the gem defaults to `limit: 100, offset: 0`.
 
 ```ruby
 # Page 1, 50 items
@@ -1043,24 +1043,35 @@ result = Conexa::Customer.all(limit: 50)
 result.data           # => Array of customers
 result.pagination.limit    # => 50
 result.pagination.offset   # => 0
-result.pagination.has_next # => true/false
+result.has_next?      # => true/false
 result.empty?         # => false
 
-# Iterate all pages
+# Iterate all pages using next_page
+result = Conexa::Customer.all(limit: 100)
+loop do
+  result.each { |customer| process(customer) }
+  break unless result.has_next?
+  result = result.next_page
+end
+
+# Or manually with offset
 offset = 0
 loop do
   result = Conexa::Customer.all(limit: 100, offset: offset)
   break if result.empty?
-
   result.each { |customer| process(customer) }
-  break unless result.pagination.has_next
+  break unless result.has_next?
   offset += 100
 end
 ```
 
+**`next_page`** — Fetches the next page automatically, preserving all original filter params. Raises `StopIteration` when there are no more pages.
+
+**`has_next?`** — Returns `true` if more pages are available.
+
 #### Legacy Pagination (deprecated — removed 2026-08-01)
 
-If `limit:` is NOT passed, the gem falls back to the old `page`/`size` model
+If `page:` or `size:` is explicitly passed, the gem uses the old pagination model
 (emitting a deprecation warning):
 
 ```ruby
@@ -1115,13 +1126,12 @@ loop do
   page += 1
 end
 
-# AFTER
-offset = 0
+# AFTER (using next_page)
+result = Conexa::Customer.all(limit: 100)
 loop do
-  result = Conexa::Customer.all(limit: 100, offset: offset)
   result.each { |c| process(c) }
-  break unless result.pagination.has_next
-  offset += 100
+  break unless result.has_next?
+  result = result.next_page
 end
 ```
 

--- a/lib/conexa.rb
+++ b/lib/conexa.rb
@@ -9,7 +9,7 @@ require_relative "conexa/core_ext"
 require_relative "conexa/errors"
 require_relative "conexa/util"
 require_relative "conexa/configuration"
-require_relative "conexa/order_commom"
+require_relative "conexa/order_common"
 require_relative "conexa/token_manager"
 
 

--- a/lib/conexa/authenticator.rb
+++ b/lib/conexa/authenticator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jwt'
 
 

--- a/lib/conexa/configuration.rb
+++ b/lib/conexa/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class Configuration
     attr_accessor :api_token, :api_host

--- a/lib/conexa/core_ext.rb
+++ b/lib/conexa/core_ext.rb
@@ -1,9 +1,14 @@
-class Object
-  def blank?
-    respond_to?(:empty?) ? !!empty? : !self
-  end
+# frozen_string_literal: true
 
-  def present?
-    !blank?
+# Only define blank?/present? if not already provided (e.g., by ActiveSupport)
+unless Object.method_defined?(:blank?)
+  class Object
+    def blank?
+      respond_to?(:empty?) ? !!empty? : !self
+    end
+
+    def present?
+      !blank?
+    end
   end
 end

--- a/lib/conexa/errors.rb
+++ b/lib/conexa/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class ConexaError < StandardError
   end
@@ -38,11 +40,11 @@ module Conexa
 
     def initialize(response)
       @response = response
-      @errors   = response['message']&.map do |message|
-        params = error.values_at('message', 'parameter_name', 'type', 'url')
+      @errors   = response['message']&.map do |msg|
+        params = msg.values_at('message', 'parameter_name', 'type', 'url')
         ParamError.new(*params)
       end
-      super @errors&.map(&:message).join(', ')
+      super @errors&.map(&:message)&.join(', ')
     end
 
     def to_h

--- a/lib/conexa/model.rb
+++ b/lib/conexa/model.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Conexa
   # Base class for all API resources (Customer, Charge, Contract, etc.)
   #
   # == Attribute Access
-  # 
+  #
   # Attributes are automatically accessible via method_missing:
   #   customer.name           # => "Empresa ABC"
   #   customer.company_id     # => 3
@@ -31,28 +33,10 @@ module Conexa
   # instead of "recurring_sale_id". Explicit declaration ensures correctness.
   #
   class Model < ConexaObject
-    class << self
-      # DSL for primary key attribute with :id alias
-      # @example
-      #   primary_key_attribute :charge_id
-      #   # Generates: charge_id method + chargeId alias + id alias
-      def primary_key_attribute(snake_name)
-        camel_name = Util.camelize_str(snake_name.to_s)
-
-        define_method(snake_name) do
-          @attributes[snake_name.to_s]
-        end
-
-        alias_method camel_name.to_sym, snake_name
-        alias_method :id, snake_name
-      end
-    end
-
     def create
       set_primary_key Conexa::Request.post(self.class.show_url, params: to_hash).call(class_name).attributes['id']
       fetch
     end
-
 
     def save
       update Conexa::Request.patch(self.class.show_url(primary_key), params: unsaved_attributes).call(class_name)
@@ -86,11 +70,26 @@ module Conexa
 
     def destroy
       raise RequestError.new('Invalid ID') unless id.present?
-      update Conexa::Request.delete( self.class.show_url(primary_key) ).call(class_name)
+      update Conexa::Request.delete(self.class.show_url(primary_key)).call(class_name)
       self
     end
 
     class << self
+      # DSL for primary key attribute with :id alias
+      # @example
+      #   primary_key_attribute :charge_id
+      #   # Generates: charge_id method + chargeId alias + id alias
+      def primary_key_attribute(snake_name)
+        camel_name = Util.camelize_str(snake_name.to_s)
+
+        define_method(snake_name) do
+          @attributes[snake_name.to_s]
+        end
+
+        alias_method camel_name.to_sym, snake_name
+        alias_method :id, snake_name
+      end
+
       def create(*args)
         self.new(*args).create
       end
@@ -100,7 +99,6 @@ module Conexa
         Conexa::Request.get(show_url(id), params: options).call underscored_class_name
       end
       alias :find :find_by_id
-
 
       def find_by(params = Hash.new, page = nil, size = nil)
         params = extract_page_size_or_params(page, size, **params)
@@ -114,8 +112,7 @@ module Conexa
       alias :find_by_hash :find_by
 
       def all(*args, **params)
-        params = extract_page_size_or_params(*args, **params)
-        find_by params
+        find_by(params, *args)
       end
       alias :where :all
 
@@ -134,7 +131,8 @@ module Conexa
       end
 
       def class_name
-        self.name.split('::').last.downcase
+        name = self.name.split('::').last
+        name[0].downcase + name[1..]
       end
 
       def underscored_class_name
@@ -152,8 +150,17 @@ module Conexa
 
         # Explicit new pagination (limit/offset)
         if params.key?(:limit)
+          unless params[:limit].is_a?(Integer) && params[:limit].positive?
+            raise RequestError, "limit must be a positive integer"
+          end
+
           params[:offset] ||= size_val if size_val.is_a?(Integer)
           params[:offset] ||= 0
+
+          unless params[:offset].is_a?(Integer) && params[:offset] >= 0
+            raise RequestError, "offset must be a non-negative integer"
+          end
+
           params.delete(:page)
           params.delete(:size)
           return params

--- a/lib/conexa/model.rb
+++ b/lib/conexa/model.rb
@@ -106,7 +106,10 @@ module Conexa
         params = extract_page_size_or_params(page, size, **params)
         raise RequestError.new('Invalid page size') if (!params.key?(:limit)) && (params[:page] < 1 or params[:size] < 1)
 
-        Conexa::Request.get(url, params: params).call underscored_class_name
+        Conexa::Request.get(url, params: params).call(
+          underscored_class_name,
+          query_context: { resource_class: self, params: params }
+        )
       end
       alias :find_by_hash :find_by
 
@@ -147,20 +150,26 @@ module Conexa
         end
         size_val = args[1]
 
+        # Explicit new pagination (limit/offset)
         if params.key?(:limit)
           params[:offset] ||= size_val if size_val.is_a?(Integer)
           params[:offset] ||= 0
-          params.delete(:page) # Fix to ensure the api doesn't get confused
+          params.delete(:page)
           params.delete(:size)
           return params
         end
 
+        # Explicit legacy pagination (page/size) — deprecated
         if params.key?(:page) || params.key?(:size) || page_val.is_a?(Integer)
           warn "DEPRECATION WARNING: O modelo antigo de paginação (page/size) será removido em 01 de agosto de 2026. Utilize limit e offset."
+          params[:page] ||= page_val || 1
+          params[:size] ||= size_val || 100
+          return params
         end
 
-        params[:page] ||= page_val || 1
-        params[:size] ||= size_val || 100
+        # Default: new pagination
+        params[:limit] = 100
+        params[:offset] = 0
         params
       end
     end

--- a/lib/conexa/object.rb
+++ b/lib/conexa/object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   # Base class for all Conexa objects with dynamic attribute access
   #
@@ -24,8 +26,6 @@ module Conexa
     end
 
     def initialize(response = {})
-      # raise MissingCredentialsError.new("Missing :client_key for extra options #{options}") if options && !options[:client_key]
-
       @attributes = Hash.new
       @unsaved_attributes = Set.new
 
@@ -57,20 +57,12 @@ module Conexa
       end]
     end
 
-    def respond_to?(name, include_all = false)
-      return true if name.to_s.end_with? '='
+    def respond_to_missing?(name, include_private = false)
+      name_str = Util.to_snake_case(name.to_s)
+      return true if name_str.end_with?('=')
 
-      @attributes.has_key?(name.to_s) || super
+      @attributes.key?(name_str) || @attributes.key?(name_str.to_sym) || super
     end
-
-    # def to_s
-    #   attributes_str = ''
-    #   (attributes.keys - ['id', 'object']).sort.each do |key|
-    #     attributes_str += " \033[1;33m#{key}:\033[0m#{self[key].inspect}" unless self[key].nil?
-    #   end
-    #   "\033[1;31m#<#{self.class.name}:\033[0;32m#{id}#{attributes_str}\033[0m\033[0m\033[1;31m>\033[0;32m"
-    # end
-    # # alias :inspect :to_s
 
     protected
     def update(attributes)
@@ -127,7 +119,6 @@ module Conexa
       super name, *args, &block
     end
 
-
     class << self
       def convert(response, resource_name = nil, client_key=nil)
         case response
@@ -154,7 +145,6 @@ module Conexa
 
       def capitalize_name(name)
         name.split('_').collect(&:capitalize).join
-        # name.gsub(/(\A\w|\_\w)/){ |str| str.gsub('_', '').upcase }
       end
     end
   end

--- a/lib/conexa/order_common.rb
+++ b/lib/conexa/order_common.rb
@@ -1,9 +1,9 @@
-module Conexa
-  class OrderCommom < Model
+# frozen_string_literal: true
 
-    # def self.url(*params)
-    #   ["/#{ CGI.escape underscored_class_name }", *params].join '/'
-    # end
+module Conexa
+  class OrderCommon < Model
+    # Keep old name as alias for backwards compatibility
+    OrderCommom = self
 
     #
     # Request refund to Conexa api for this order

--- a/lib/conexa/request.rb
+++ b/lib/conexa/request.rb
@@ -1,8 +1,8 @@
+# frozen_string_literal: true
+
 require 'uri'
 require 'rest_client'
 require 'multi_json'
-
-
 
 module Conexa
   class Request
@@ -28,7 +28,6 @@ module Conexa
 
       response = MultiJson.decode response.body
       return {data: response.dig("data") || response, pagination: response.dig("pagination")}
-
 
       rescue RestClient::Exception => error
         begin
@@ -60,18 +59,18 @@ module Conexa
         raise Conexa::ConnectionError.new $!
     end
 
-    def call(ressource_name, query_context: nil)
+    def call(resource_name, query_context: nil)
       dt = run
 
       if dt[:pagination]
         result = ConexaObject.convert({
-          data: ConexaObject.convert(dt[:data], ressource_name),
+          data: ConexaObject.convert(dt[:data], resource_name),
           pagination: ConexaObject.convert(dt[:pagination], "pagination")}, "result")
         result.instance_variable_set(:@query_context, query_context) if query_context
         return result
       end
 
-      ConexaObject.convert(dt[:data], ressource_name)
+      ConexaObject.convert(dt[:data], resource_name)
     end
 
     def self.get(url, options={})
@@ -107,7 +106,7 @@ module Conexa
       @parameters = Util.camelize_hash(@parameters)
       aux.merge!({ payload:   MultiJson.encode(@parameters)}) unless %w(GET DELETE).include? method
 
-      extra_headers = DEFAULT_HEADERS
+      extra_headers = DEFAULT_HEADERS.dup
       extra_headers[:authorization] = "Bearer #{Conexa.configuration.api_token}" unless @auth
       extra_headers[:params] = @parameters if method == "GET"
       aux.merge!({ headers: extra_headers })

--- a/lib/conexa/request.rb
+++ b/lib/conexa/request.rb
@@ -60,13 +60,15 @@ module Conexa
         raise Conexa::ConnectionError.new $!
     end
 
-    def call(ressource_name)
+    def call(ressource_name, query_context: nil)
       dt = run
 
       if dt[:pagination]
-        return ConexaObject.convert({
+        result = ConexaObject.convert({
           data: ConexaObject.convert(dt[:data], ressource_name),
           pagination: ConexaObject.convert(dt[:pagination], "pagination")}, "result")
+        result.instance_variable_set(:@query_context, query_context) if query_context
+        return result
       end
 
       ConexaObject.convert(dt[:data], ressource_name)

--- a/lib/conexa/resources/bill.rb
+++ b/lib/conexa/resources/bill.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Conexa
   class Bill  < Model
     def save
-      raise NoMethodError
+      raise NoMethodError, "Bill does not support save"
     end
   end
 end

--- a/lib/conexa/resources/company.rb
+++ b/lib/conexa/resources/company.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class Company  < Model
 

--- a/lib/conexa/resources/credit_card.rb
+++ b/lib/conexa/resources/credit_card.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class CreditCard < Model
     primary_key_attribute :credit_card_id

--- a/lib/conexa/resources/invoicing_method.rb
+++ b/lib/conexa/resources/invoicing_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class InvoicingMethod < Model
     primary_key_attribute :invoicing_method_id

--- a/lib/conexa/resources/legal_person.rb
+++ b/lib/conexa/resources/legal_person.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class LegalPerson  < ConexaObject
   end

--- a/lib/conexa/resources/pagination.rb
+++ b/lib/conexa/resources/pagination.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class Pagination  < ConexaObject
   end

--- a/lib/conexa/resources/person.rb
+++ b/lib/conexa/resources/person.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class Person < Model
   end

--- a/lib/conexa/resources/plan.rb
+++ b/lib/conexa/resources/plan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class Plan  < Model
 

--- a/lib/conexa/resources/product.rb
+++ b/lib/conexa/resources/product.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   # Product resource (read-only for listing/retrieving)
   #

--- a/lib/conexa/resources/recurring_sale.rb
+++ b/lib/conexa/resources/recurring_sale.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class RecurringSale < Model
     primary_key_attribute :recurring_sale_id

--- a/lib/conexa/resources/result.rb
+++ b/lib/conexa/resources/result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
   class Result  < ConexaObject
 
@@ -25,7 +27,7 @@ module Conexa
       raise "No query context available for next_page" unless @query_context
 
       resource_class = @query_context[:resource_class]
-      next_params = @query_context[:params].dup
+      next_params = Marshal.load(Marshal.dump(@query_context[:params]))
 
       next_params[:limit] = pagination.limit
       next_params[:offset] = pagination.offset + pagination.limit
@@ -35,10 +37,12 @@ module Conexa
       resource_class.find_by(next_params)
     end
 
-    def respond_to?(name, include_all = false)
-      return true if name.to_s.end_with? '='
+    def respond_to_missing?(name, include_private = false)
+      name_str = Util.to_snake_case(name.to_s)
+      return true if name_str.end_with?('=')
+      return true if @attributes["data"]&.respond_to?(name_str)
 
-      @attributes.has_key?(name.to_s) ||      super
+      @attributes.key?(name_str) || @attributes.key?(name_str.to_sym) || super
     end
 
     def method_missing(name, *args, &block)
@@ -49,14 +53,18 @@ module Conexa
       end
 
       unless block_given?
-
         if name.end_with?('=') && args.size == 1
           attribute_name = name[0...-1]
           return self[attribute_name] = args[0]
         end
 
         if args.size == 0
-          return self[name] || self[name.to_sym]
+          if @attributes.key?(name)
+            return @attributes[name]
+          elsif @attributes.key?(name.to_sym)
+            return @attributes[name.to_sym]
+          end
+          return nil
         end
       end
 

--- a/lib/conexa/resources/result.rb
+++ b/lib/conexa/resources/result.rb
@@ -16,6 +16,25 @@ module Conexa
       @attributes["pagination"]
     end
 
+    def has_next?
+      pagination && pagination.has_next == true
+    end
+
+    def next_page
+      raise StopIteration, "No more pages" unless has_next?
+      raise "No query context available for next_page" unless @query_context
+
+      resource_class = @query_context[:resource_class]
+      next_params = @query_context[:params].dup
+
+      next_params[:limit] = pagination.limit
+      next_params[:offset] = pagination.offset + pagination.limit
+      next_params.delete(:page)
+      next_params.delete(:size)
+
+      resource_class.find_by(next_params)
+    end
+
     def respond_to?(name, include_all = false)
       return true if name.to_s.end_with? '='
 

--- a/lib/conexa/token_manager.rb
+++ b/lib/conexa/token_manager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Conexa
 
   #
@@ -19,7 +21,7 @@ module Conexa
         when Array
           tokens = Conexa.credentials
         when Hash
-          tokens = [ShiConexa.credentials]
+          tokens = [Conexa.credentials]
         end
       else
         tokens = [{

--- a/lib/conexa/util.rb
+++ b/lib/conexa/util.rb
@@ -1,44 +1,46 @@
+# frozen_string_literal: true
+
 module Conexa
   class Util
     class << self
 
-      SINGULARS = {
-        '/s$/i' => "",
-        '/(ss)$/i' => '\1',
-        '/(n)ews$/i' => '\1ews',
-        '/([ti])a$/i' => '\1um',
-        '/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i' => '\1sis',
-        '/(^analy)(sis|ses)$/i' => '\1sis',
-        '/([^f])ves$/i' => '\1fe',
-        '/(hive)s$/i' => '\1',
-        '/(tive)s$/i' => '\1',
-        '/([lr])ves$/i' => '\1f',
-        '/([^aeiouy]|qu)ies$/i' => '\1y',
-        '/(s)eries$/i' => '\1eries',
-        '/(m)ovies$/i' => '\1ovie',
-        '/(x|ch|ss|sh)es$/i' => '\1',
-        '/^(m|l)ice$/i' => '\1ouse',-
-        '/(bus)(es)?$/i' => '\1',
-        '/(o)es$/i' => '\1',
-        '/(shoe)s$/i' => '\1',
-        '/(cris|test)(is|es)$/i' => '\1is',
-        '/^(a)x[ie]s$/i' => '\1xis',
-        '/(octop|vir)(us|i)$/i' => '\1us',
-        '/(alias|status)(es)?$/i' => '\1',
-        '/^(ox)en/i' => '\1',
-        '/(vert|ind)ices$/i' => '\1ex',
-        '/(matr)ices$/i' => '\1ix',
-        '/(quiz)zes$/i' => '\1',
-        '/(database)s$/i' => '\1'}
+      SINGULARS = [
+        [/(ss)$/i, '\1'],
+        [/(n)ews$/i, '\1ews'],
+        [/([ti])a$/i, '\1um'],
+        [/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i, '\1sis'],
+        [/(^analy)(sis|ses)$/i, '\1sis'],
+        [/([^f])ves$/i, '\1fe'],
+        [/(hive)s$/i, '\1'],
+        [/(tive)s$/i, '\1'],
+        [/([lr])ves$/i, '\1f'],
+        [/([^aeiouy]|qu)ies$/i, '\1y'],
+        [/(s)eries$/i, '\1eries'],
+        [/(m)ovies$/i, '\1ovie'],
+        [/(x|ch|ss|sh)es$/i, '\1'],
+        [/^(m|l)ice$/i, '\1ouse'],
+        [/(bus)(es)?$/i, '\1'],
+        [/(o)es$/i, '\1'],
+        [/(shoe)s$/i, '\1'],
+        [/(cris|test)(is|es)$/i, '\1is'],
+        [/^(a)x[ie]s$/i, '\1xis'],
+        [/(octop|vir)(us|i)$/i, '\1us'],
+        [/(alias|status)(es)?$/i, '\1'],
+        [/^(ox)en/i, '\1'],
+        [/(vert|ind)ices$/i, '\1ex'],
+        [/(matr)ices$/i, '\1ix'],
+        [/(quiz)zes$/i, '\1'],
+        [/(database)s$/i, '\1'],
+        [/s$/i, '']
+      ].freeze
 
-      def singularize resource
-        out = ''
-        SINGULARS.keys.each do |key|
-          out = resource.to_s.gsub(/s$/,SINGULARS[key])
-          break out if out != resource
+      def singularize(resource)
+        str = resource.to_s
+        SINGULARS.each do |pattern, replacement|
+          result = str.sub(pattern, replacement)
+          return resource.is_a?(Symbol) ? result.to_sym : result if result != str
         end
-
-        resource.is_a?(Symbol) ? out.to_sym : out
+        resource
       end
 
       def to_sym string
@@ -74,21 +76,6 @@ module Conexa
         str.to_s.split('_').inject([]){ |buffer,e| buffer.push(buffer.empty? ? e : e.capitalize) }.join
       end
 
-    end
-  end
-end
-
-class Hash
-  def except_nested(key)
-    r = Marshal.load(Marshal.dump(self))
-    r.except_nested!(key)
-  end
-
-  def except_nested!(key)
-    self.reject!{|k, _| k == key || k.to_s == key }
-    self.each do |_, v|
-      v.except_nested!(key) if v.is_a?(Hash)
-      v.map!{|obj| obj.except_nested!(key) if obj.is_a?(Hash)} if v.is_a?(Array)
     end
   end
 end

--- a/lib/conexa/version.rb
+++ b/lib/conexa/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Conexa
-  VERSION = "0.0.9"
+  VERSION = "0.1.0"
 end

--- a/spec/conexa/model_spec.rb
+++ b/spec/conexa/model_spec.rb
@@ -93,6 +93,36 @@ RSpec.describe Conexa::Model do
         expect(result[:limit]).to eq(20)
         expect(result[:status]).to eq('active')
       end
+
+      it 'raises on non-positive limit' do
+        expect { model_class.extract_page_size_or_params(limit: 0) }
+          .to raise_error(Conexa::RequestError, /limit must be a positive integer/)
+      end
+
+      it 'raises on negative limit' do
+        expect { model_class.extract_page_size_or_params(limit: -5) }
+          .to raise_error(Conexa::RequestError, /limit must be a positive integer/)
+      end
+
+      it 'raises on non-integer limit' do
+        expect { model_class.extract_page_size_or_params(limit: 'abc') }
+          .to raise_error(Conexa::RequestError, /limit must be a positive integer/)
+      end
+
+      it 'raises on negative offset' do
+        expect { model_class.extract_page_size_or_params(limit: 10, offset: -1) }
+          .to raise_error(Conexa::RequestError, /offset must be a non-negative integer/)
+      end
+    end
+  end
+
+  describe '.class_name' do
+    it 'returns lowerCamelCase for compound names' do
+      expect(Conexa::RecurringSale.class_name).to eq('recurringSale')
+    end
+
+    it 'returns lowercase for simple names' do
+      expect(model_class.class_name).to eq('customer')
     end
   end
 end

--- a/spec/conexa/model_spec.rb
+++ b/spec/conexa/model_spec.rb
@@ -59,10 +59,12 @@ RSpec.describe Conexa::Model do
       expect(result[:size]).to eq(100)
     end
 
-    it 'defaults to page 1, size 100' do
+    it 'defaults to limit 100, offset 0 (new pagination)' do
       result = model_class.extract_page_size_or_params
-      expect(result[:page]).to eq(1)
-      expect(result[:size]).to eq(100)
+      expect(result[:limit]).to eq(100)
+      expect(result[:offset]).to eq(0)
+      expect(result).not_to have_key(:page)
+      expect(result).not_to have_key(:size)
     end
 
     it 'preserves additional params' do

--- a/spec/conexa/new_pagination_spec.rb
+++ b/spec/conexa/new_pagination_spec.rb
@@ -138,6 +138,176 @@ RSpec.describe 'New Pagination (limit/offset/hasNext)' do
     end
   end
 
+  describe 'default pagination (no params)' do
+    it 'defaults to limit/offset instead of page/size' do
+      result = Conexa::Customer.send(:extract_page_size_or_params)
+      expect(result[:limit]).to eq(100)
+      expect(result[:offset]).to eq(0)
+      expect(result).not_to have_key(:page)
+      expect(result).not_to have_key(:size)
+    end
+
+    it 'does not emit deprecation warning' do
+      expect { Conexa::Customer.send(:extract_page_size_or_params) }
+        .not_to output.to_stderr
+    end
+  end
+
+  describe '#has_next?' do
+    it 'returns true when has_next is true' do
+      stub_request(:get, "#{api_base}/customers")
+        .with(query: hash_including({ 'limit' => '10', 'offset' => '0' }))
+        .to_return(
+          status: 200,
+          body: {
+            data: [{ customerId: 1, name: 'Customer 1' }],
+            pagination: { limit: 10, offset: 0, hasNext: true }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = Conexa::Customer.all(limit: 10)
+      expect(result.has_next?).to be true
+    end
+
+    it 'returns false when has_next is false' do
+      stub_request(:get, "#{api_base}/customers")
+        .with(query: hash_including({ 'limit' => '10', 'offset' => '0' }))
+        .to_return(
+          status: 200,
+          body: {
+            data: [],
+            pagination: { limit: 10, offset: 0, hasNext: false }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = Conexa::Customer.all(limit: 10)
+      expect(result.has_next?).to be false
+    end
+  end
+
+  describe '#next_page' do
+    it 'fetches the next page with correct offset' do
+      stub_request(:get, "#{api_base}/customers")
+        .with(query: hash_including({ 'limit' => '10', 'offset' => '0' }))
+        .to_return(
+          status: 200,
+          body: {
+            data: [{ customerId: 1, name: 'Customer 1' }],
+            pagination: { limit: 10, offset: 0, hasNext: true }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      stub_request(:get, "#{api_base}/customers")
+        .with(query: hash_including({ 'limit' => '10', 'offset' => '10' }))
+        .to_return(
+          status: 200,
+          body: {
+            data: [{ customerId: 2, name: 'Customer 2' }],
+            pagination: { limit: 10, offset: 10, hasNext: false }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      page1 = Conexa::Customer.all(limit: 10)
+      page2 = page1.next_page
+
+      expect(page2).to be_a(Conexa::Result)
+      expect(page2.data.first.name).to eq('Customer 2')
+      expect(page2.pagination.offset).to eq(10)
+      expect(page2.has_next?).to be false
+    end
+
+    it 'preserves original filter params' do
+      stub_request(:get, "#{api_base}/customers")
+        .with(query: hash_including({ 'limit' => '10', 'offset' => '0', 'isActive' => 'true' }))
+        .to_return(
+          status: 200,
+          body: {
+            data: [{ customerId: 1, name: 'Customer 1' }],
+            pagination: { limit: 10, offset: 0, hasNext: true }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      stub_request(:get, "#{api_base}/customers")
+        .with(query: hash_including({ 'limit' => '10', 'offset' => '10', 'isActive' => 'true' }))
+        .to_return(
+          status: 200,
+          body: {
+            data: [{ customerId: 2, name: 'Customer 2' }],
+            pagination: { limit: 10, offset: 10, hasNext: false }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      page1 = Conexa::Customer.all(limit: 10, is_active: true)
+      page2 = page1.next_page
+
+      expect(page2.data.first.name).to eq('Customer 2')
+    end
+
+    it 'raises StopIteration when no more pages' do
+      stub_request(:get, "#{api_base}/customers")
+        .with(query: hash_including({ 'limit' => '10', 'offset' => '0' }))
+        .to_return(
+          status: 200,
+          body: {
+            data: [{ customerId: 1, name: 'Customer 1' }],
+            pagination: { limit: 10, offset: 0, hasNext: false }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = Conexa::Customer.all(limit: 10)
+      expect { result.next_page }.to raise_error(StopIteration, "No more pages")
+    end
+
+    it 'chains multiple next_page calls' do
+      stub_request(:get, "#{api_base}/customers")
+        .with(query: hash_including({ 'limit' => '5', 'offset' => '0' }))
+        .to_return(
+          status: 200,
+          body: {
+            data: [{ customerId: 1 }],
+            pagination: { limit: 5, offset: 0, hasNext: true }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      stub_request(:get, "#{api_base}/customers")
+        .with(query: hash_including({ 'limit' => '5', 'offset' => '5' }))
+        .to_return(
+          status: 200,
+          body: {
+            data: [{ customerId: 2 }],
+            pagination: { limit: 5, offset: 5, hasNext: true }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      stub_request(:get, "#{api_base}/customers")
+        .with(query: hash_including({ 'limit' => '5', 'offset' => '10' }))
+        .to_return(
+          status: 200,
+          body: {
+            data: [{ customerId: 3 }],
+            pagination: { limit: 5, offset: 10, hasNext: false }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      page1 = Conexa::Customer.all(limit: 5)
+      page2 = page1.next_page
+      page3 = page2.next_page
+
+      expect(page3.data.first.customer_id).to eq(3)
+      expect(page3.has_next?).to be false
+    end
+  end
+
   describe 'new resources with new pagination' do
     it 'works with ReceivingMethod' do
       stub_request(:get, "#{api_base}/receivingMethods")

--- a/spec/conexa/pagination_edge_cases_spec.rb
+++ b/spec/conexa/pagination_edge_cases_spec.rb
@@ -226,22 +226,22 @@ RSpec.describe 'Pagination Edge Cases' do
   end
 
   describe 'Default pagination' do
-    it 'uses default page=1 and size=100 when not specified' do
+    it 'uses default limit=100 and offset=0 when not specified' do
       stub_request(:get, "#{api_base}/customers")
-        .with(query: hash_including({ 'page' => '1', 'size' => '100' }))
+        .with(query: hash_including({ 'limit' => '100', 'offset' => '0' }))
         .to_return(
           status: 200,
           body: {
             data: [],
-            pagination: { page: 1, size: 100, totalPages: 0, totalElements: 0 }
+            pagination: { limit: 100, offset: 0, hasNext: false }
           }.to_json,
           headers: { 'Content-Type' => 'application/json' }
         )
 
       result = Conexa::Customer.all
 
-      expect(result.pagination.page).to eq(1)
-      expect(result.pagination.size).to eq(100)
+      expect(result.pagination.limit).to eq(100)
+      expect(result.pagination.offset).to eq(0)
     end
   end
 

--- a/spec/conexa/resources/new_resources_spec.rb
+++ b/spec/conexa/resources/new_resources_spec.rb
@@ -1,0 +1,521 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'New API v2 Resources' do
+  let(:api_host) { 'https://checkbits.conexa.app' }
+  let(:api_base) { "#{api_host}/index.php/api/v2" }
+
+  around(:each) do |example|
+    VCR.turned_off do
+      WebMock.enable!
+      example.run
+    end
+  end
+
+  before(:each) do
+    Conexa.configure do |c|
+      c.api_token = 'test_token'
+      c.api_host = api_host
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # M3 - Integration tests for new resources
+  # ---------------------------------------------------------------------------
+
+  describe Conexa::ReceivingMethod do
+    describe '.all' do
+      it 'lists receiving methods' do
+        stub_request(:get, "#{api_base}/receivingMethods")
+          .with(query: hash_including({ 'limit' => '10', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [
+                { receivingMethodId: 10, name: 'Dinheiro', isActive: true },
+                { receivingMethodId: 11, name: 'Cartao de Credito', isActive: true }
+              ],
+              pagination: { limit: 10, offset: 0, hasNext: false }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::ReceivingMethod.all(limit: 10)
+
+        expect(result).to be_a(Conexa::Result)
+        expect(result.data.size).to eq(2)
+        expect(result.data.first.name).to eq('Dinheiro')
+        expect(result.data.last.name).to eq('Cartao de Credito')
+        expect(result.pagination.has_next).to be false
+      end
+    end
+
+    describe '.find' do
+      it 'finds a receiving method by id' do
+        stub_request(:get, "#{api_base}/receivingMethod/10")
+          .to_return(
+            status: 200,
+            body: { receivingMethodId: 10, name: 'Dinheiro', isActive: true }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        method = Conexa::ReceivingMethod.find(10)
+
+        expect(method.name).to eq('Dinheiro')
+        expect(method.is_active).to be true
+      end
+    end
+  end
+
+  describe Conexa::PaymentMethod do
+    describe '.all' do
+      it 'lists payment methods' do
+        stub_request(:get, "#{api_base}/paymentMethods")
+          .with(query: hash_including({ 'limit' => '20', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [{ paymentMethodId: 1, name: 'Boleto', isActive: true }],
+              pagination: { limit: 20, offset: 0, hasNext: false }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::PaymentMethod.all(limit: 20)
+
+        expect(result).to be_a(Conexa::Result)
+        expect(result.data.size).to eq(1)
+        expect(result.data.first.name).to eq('Boleto')
+      end
+    end
+
+    describe '.find' do
+      it 'finds a payment method by id' do
+        stub_request(:get, "#{api_base}/paymentMethod/1")
+          .to_return(
+            status: 200,
+            body: { paymentMethodId: 1, name: 'Boleto', isActive: true }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        method = Conexa::PaymentMethod.find(1)
+
+        expect(method.name).to eq('Boleto')
+      end
+    end
+  end
+
+  describe Conexa::BillCategory do
+    describe '.all' do
+      it 'lists bill categories' do
+        stub_request(:get, "#{api_base}/billCategories")
+          .with(query: hash_including({ 'limit' => '20', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [
+                { billCategoryId: 4, name: 'Impostos' },
+                { billCategoryId: 5, name: 'Folha de Pagamento' }
+              ],
+              pagination: { limit: 20, offset: 0, hasNext: true }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::BillCategory.all(limit: 20)
+
+        expect(result).to be_a(Conexa::Result)
+        expect(result.data.size).to eq(2)
+        expect(result.data.first.name).to eq('Impostos')
+        expect(result.pagination.has_next).to be true
+      end
+    end
+
+    describe '.find' do
+      it 'finds a bill category by id' do
+        stub_request(:get, "#{api_base}/billCategory/4")
+          .to_return(
+            status: 200,
+            body: { billCategoryId: 4, name: 'Impostos' }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        category = Conexa::BillCategory.find(4)
+
+        expect(category.name).to eq('Impostos')
+      end
+    end
+  end
+
+  describe Conexa::BillSubcategory do
+    describe '.all' do
+      it 'lists bill subcategories' do
+        stub_request(:get, "#{api_base}/billSubcategories")
+          .with(query: hash_including({ 'limit' => '15', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [{ billSubcategoryId: 12, name: 'ISS', billCategoryId: 4 }],
+              pagination: { limit: 15, offset: 0, hasNext: false }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::BillSubcategory.all(limit: 15)
+
+        expect(result).to be_a(Conexa::Result)
+        expect(result.data.size).to eq(1)
+        expect(result.data.first.name).to eq('ISS')
+      end
+    end
+
+    describe '.find' do
+      it 'finds a bill subcategory by id' do
+        stub_request(:get, "#{api_base}/billSubcategory/12")
+          .to_return(
+            status: 200,
+            body: { billSubcategoryId: 12, name: 'ISS', billCategoryId: 4 }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        subcategory = Conexa::BillSubcategory.find(12)
+
+        expect(subcategory.name).to eq('ISS')
+      end
+    end
+  end
+
+  describe Conexa::CostCenter do
+    describe '.all' do
+      it 'lists cost centers' do
+        stub_request(:get, "#{api_base}/costCenters")
+          .with(query: hash_including({ 'limit' => '10', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [{ costCenterId: 7, name: 'Administrativo', isActive: true }],
+              pagination: { limit: 10, offset: 0, hasNext: false }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::CostCenter.all(limit: 10)
+
+        expect(result).to be_a(Conexa::Result)
+        expect(result.data.size).to eq(1)
+        expect(result.data.first.name).to eq('Administrativo')
+      end
+    end
+
+    describe '.find' do
+      it 'finds a cost center by id' do
+        stub_request(:get, "#{api_base}/costCenter/7")
+          .to_return(
+            status: 200,
+            body: { costCenterId: 7, name: 'Administrativo', isActive: true }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        cost_center = Conexa::CostCenter.find(7)
+
+        expect(cost_center.name).to eq('Administrativo')
+        expect(cost_center.is_active).to be true
+      end
+    end
+  end
+
+  describe Conexa::Account do
+    describe '.all' do
+      it 'lists accounts' do
+        stub_request(:get, "#{api_base}/accounts")
+          .with(query: hash_including({ 'limit' => '50', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [
+                { accountId: 1, name: 'Banco do Brasil', isActive: true },
+                { accountId: 2, name: 'Caixa Economica', isActive: true }
+              ],
+              pagination: { limit: 50, offset: 0, hasNext: false }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::Account.all(limit: 50)
+
+        expect(result).to be_a(Conexa::Result)
+        expect(result.data.size).to eq(2)
+        expect(result.data.first.name).to eq('Banco do Brasil')
+        expect(result.data.last.name).to eq('Caixa Economica')
+      end
+    end
+
+    describe '.find' do
+      it 'finds an account by id' do
+        stub_request(:get, "#{api_base}/account/1")
+          .to_return(
+            status: 200,
+            body: { accountId: 1, name: 'Banco do Brasil', isActive: true }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        account = Conexa::Account.find(1)
+
+        expect(account.name).to eq('Banco do Brasil')
+      end
+    end
+  end
+
+  describe Conexa::ServiceCategory do
+    describe '.all' do
+      it 'lists service categories' do
+        stub_request(:get, "#{api_base}/serviceCategories")
+          .with(query: hash_including({ 'limit' => '25', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [{ serviceCategoryId: 3, name: 'Consultoria' }],
+              pagination: { limit: 25, offset: 0, hasNext: false }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::ServiceCategory.all(limit: 25)
+
+        expect(result).to be_a(Conexa::Result)
+        expect(result.data.size).to eq(1)
+        expect(result.data.first.name).to eq('Consultoria')
+      end
+    end
+
+    describe '.find' do
+      it 'finds a service category by id' do
+        stub_request(:get, "#{api_base}/serviceCategory/3")
+          .to_return(
+            status: 200,
+            body: { serviceCategoryId: 3, name: 'Consultoria' }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        category = Conexa::ServiceCategory.find(3)
+
+        expect(category.name).to eq('Consultoria')
+      end
+    end
+  end
+
+  describe Conexa::RoomBooking do
+    describe '.all' do
+      it 'lists room bookings via /room/bookings' do
+        stub_request(:get, "#{api_base}/room/bookings")
+          .with(query: hash_including({ 'limit' => '10', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [
+                { bookingId: 143063, roomId: 5, customerId: 127, status: 'confirmed' },
+                { bookingId: 143064, roomId: 6, customerId: 200, status: 'pending' }
+              ],
+              pagination: { limit: 10, offset: 0, hasNext: true }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::RoomBooking.all(limit: 10)
+
+        expect(result).to be_a(Conexa::Result)
+        expect(result.data.size).to eq(2)
+        expect(result.data.first.status).to eq('confirmed')
+        expect(result.pagination.has_next).to be true
+      end
+    end
+
+    describe '.find' do
+      it 'finds a room booking via /room/booking/:id' do
+        stub_request(:get, "#{api_base}/room/booking/143063")
+          .to_return(
+            status: 200,
+            body: { bookingId: 143063, roomId: 5, customerId: 127, status: 'confirmed' }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        booking = Conexa::RoomBooking.find(143063)
+
+        expect(booking.room_id).to eq(5)
+        expect(booking.customer_id).to eq(127)
+        expect(booking.status).to eq('confirmed')
+      end
+    end
+  end
+
+  describe Conexa::Product do
+    describe '.all' do
+      it 'lists products' do
+        stub_request(:get, "#{api_base}/products")
+          .with(query: hash_including({ 'limit' => '30', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [
+                { productId: 100, name: 'Mensalidade', isActive: true },
+                { productId: 101, name: 'Taxa de Matricula', isActive: true }
+              ],
+              pagination: { limit: 30, offset: 0, hasNext: false }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::Product.all(limit: 30)
+
+        expect(result).to be_a(Conexa::Result)
+        expect(result.data.size).to eq(2)
+        expect(result.data.first.name).to eq('Mensalidade')
+        expect(result.data.last.name).to eq('Taxa de Matricula')
+      end
+    end
+
+    describe '.find' do
+      it 'finds a product by id' do
+        stub_request(:get, "#{api_base}/product/100")
+          .to_return(
+            status: 200,
+            body: { productId: 100, name: 'Mensalidade', isActive: true }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        product = Conexa::Product.find(100)
+
+        expect(product.name).to eq('Mensalidade')
+        expect(product.is_active).to be true
+      end
+    end
+
+    describe '.create' do
+      it 'creates a product via POST /product' do
+        stub_request(:post, "#{api_base}/product")
+          .to_return(
+            status: 200,
+            body: { id: 200 }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        stub_request(:get, "#{api_base}/product/200")
+          .to_return(
+            status: 200,
+            body: { productId: 200, name: 'Novo Produto', isActive: true }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        product = Conexa::Product.create(name: 'Novo Produto', company_id: 3)
+
+        expect(product.name).to eq('Novo Produto')
+        expect(product.product_id).to eq(200)
+      end
+    end
+
+    describe '.destroy' do
+      it 'deletes a product via DELETE /product/:id' do
+        stub_request(:get, "#{api_base}/product/100")
+          .to_return(
+            status: 200,
+            body: { productId: 100, name: 'Mensalidade', isActive: true }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        stub_request(:delete, "#{api_base}/product/100")
+          .to_return(
+            status: 200,
+            body: { productId: 100, name: 'Mensalidade', isActive: false }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::Product.destroy(100)
+
+        expect(result).to be_truthy
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # M4 - Legacy pagination compatibility with next_page / has_next?
+  # ---------------------------------------------------------------------------
+
+  describe 'Legacy pagination compatibility' do
+    describe '#has_next?' do
+      it 'returns false when API returns legacy pagination format (page/size/total)' do
+        stub_request(:get, "#{api_base}/customers")
+          .with(query: hash_including({ 'limit' => '10', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [{ customerId: 1, name: 'Customer 1' }],
+              pagination: { page: 1, size: 10, total: 1 }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::Customer.all(limit: 10)
+
+        expect(result.has_next?).to be false
+      end
+
+      it 'returns false when pagination has no hasNext field at all' do
+        stub_request(:get, "#{api_base}/customers")
+          .with(query: hash_including({ 'limit' => '10', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [{ customerId: 1, name: 'Customer 1' }],
+              pagination: { page: 1, size: 10 }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::Customer.all(limit: 10)
+
+        expect(result.has_next?).to be false
+      end
+    end
+
+    describe '#next_page' do
+      it 'raises StopIteration when pagination does not have hasNext' do
+        stub_request(:get, "#{api_base}/customers")
+          .with(query: hash_including({ 'limit' => '10', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [{ customerId: 1, name: 'Customer 1' }],
+              pagination: { page: 1, size: 10, total: 1 }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::Customer.all(limit: 10)
+
+        expect { result.next_page }.to raise_error(StopIteration, 'No more pages')
+      end
+
+      it 'raises StopIteration when legacy pagination has total equal to current count' do
+        stub_request(:get, "#{api_base}/customers")
+          .with(query: hash_including({ 'limit' => '50', 'offset' => '0' }))
+          .to_return(
+            status: 200,
+            body: {
+              data: [
+                { customerId: 1, name: 'Customer 1' },
+                { customerId: 2, name: 'Customer 2' }
+              ],
+              pagination: { page: 1, size: 50, total: 2 }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        result = Conexa::Customer.all(limit: 50)
+
+        expect(result.has_next?).to be false
+        expect { result.next_page }.to raise_error(StopIteration, 'No more pages')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Default pagination changed from `page: 1, size: 100` to `limit: 100, offset: 0`
- `Result#next_page` — fetches next page automatically, preserving filters
- `Result#has_next?` — convenience boolean for page availability
- Pagination migration guide (EN/PT-BR) in READMEs and REFERENCE.md
- Version bumped to 0.1.0

## Test plan
- [x] 472 specs passing (0 failures)
- [x] New pagination default tests
- [x] `next_page` tests: basic, chained, filter preservation, StopIteration
- [x] `has_next?` tests
- [x] Legacy page/size still works with deprecation warning